### PR TITLE
Fix link to RST-utility

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -80,7 +80,7 @@ Adding documentation
 
 .. sidebar:: Forger
 
-   If you want to save yourself some time you can use the rst Helper at https://forger.typo3.org/standard/rst
+   If you want to save yourself some time you can use the rst Helper at https://forger.typo3.org/utility/rst
 
    Select the type of rst snippet you want to create, enter your issue number and click the search button.
 


### PR DESCRIPTION
The link to the RST-utility was incorrect.
https://forger.typo3.org/standard/rst is wrong, https://forger.typo3.org/utility/rst is correct