### PR TITLE
fix wrong headline of 'cglFixMyCommit.bat'

### DIFF
--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -129,8 +129,8 @@ This will show necessary modifications. To apply the modifications, run it witho
 `Build/Scripts/cglFixMyCommit.sh`
 
 
-Linux and MacOS
-~~~~~~~~~~~~~~~
+Windows
+~~~~~~~
 
 `Build/Scripts/cglFixMyCommit.bat`
 


### PR DESCRIPTION
this PR changes the headline for running `Build/Scripts/cglFixMyCommit.bat` from *Linux and MacOS* to *Windows*

Cheers,
Stephan