### PR TITLE
Document trustedHostPatterns issues

### DIFF
--- a/Documentation/Appendix/SpecificTopics/DdevSettingUpTypo3.rst
+++ b/Documentation/Appendix/SpecificTopics/DdevSettingUpTypo3.rst
@@ -123,6 +123,8 @@ If you use the HTTPS url you may get a "Privacy error" or something similar from
 
 The warning is due to the fact that self-signed certificates are being used. 
 
+If you are getting a `trustedHostsPattern` error on initial access, try accessing the HTTP domain first.
+
 Additional setup
 ================
 


### PR DESCRIPTION
On initial start the AdditionalConfiguration.php written by ddev is not taken into account and due to the usage of an ssl proxy the domain host name check fails.