### PR TITLE
Update information, remove duplicates, restructure

### DIFF
--- a/Documentation/Appendix/CommitHook.rst
+++ b/Documentation/Appendix/CommitHook.rst
@@ -4,14 +4,18 @@
 .. _commit-hook:
 
 ============
-Commit hooks
+Commit Hooks
 ============
 
 .. _why-a-commit-msg-hook:
-.. _why-pre-commit-hook:
+.. _commit-msg-hook:
 
-Why a commit-msg hook?
-======================
+`commit-msg` Hook
+=================
+
+* File: :file:`.git/hooks/commit-msg`
+* Source file: :file:`Build/git-hooks/commit-msg`
+This hook is mandatory. It **must** be used for core contribution!
 
 First of all, this hook will be executed whenever you do a commit on your local machine.
 
@@ -22,6 +26,31 @@ a Change-Id on your own, the result will be chaos.
 
 Apart from that the hook will check your commit message for logical errors like missing keywords, Resolves lines etc.
 For detailed information on the format of a commit message, :ref:`click here<commitmessage>`.
+
+If the commit-msg hook finds errors in your commit-msg, you can try again, by ammending to the commit::
+
+   git commit --amend
+
+.. _why-pre-commit-hook:
+.. _pre-commit-hook:
+
+`pre-commit` Hook
+=================
+
+* File: :file:`.git/hooks/pre-commit`
+* Source file: :file:`Build/git-hooks/unix+mac/pre-commit`
+* This hook is optional. **This hook is not available for Windows.**
+
+The :file:`pre-commit` hook checks all added PHP files staged for the commit for Coding
+Guideline issues and will report any problems it finds.
+
+To fix the issues, see :ref:`cgl-fix-my-commit`.
+
+After fixing the files you must amend your
+commit::
+
+   git commit -a --amend
+
 
 
 .. _post-checkout-for-composer-update:

--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -237,33 +237,14 @@ the commit message:
 
 You will find  more information about the life cycle of a patch here :ref:`lifeOfAPatch-Reverting-Patches`.
 
-.. _committemplate:
+
 
 Commit Template
 ===============
 
-You can use a custom template for automatically generating a commit message with the basics. When editing the commit message during a commit, you can then add the necessary information. 
+You can use a custom template for automatically generating a commit message with the basics.
 
-This is a sample template::
-
-   [BUGFIX|TASK|FEATURE]
-
-   Resolves: #
-   Releases: master, 8.7
-
-Put this in a file, for example :file:`~/.gitmessage.txt`, and then configure it as template:
-
-.. code-block:: shell
-
-   git config --global commit.template ~/.gitmessage.txt
-
-This will add the template to your global git configuration (stored for your user, e.g. in ~/.gitconfig). You may not want to do this, because then the template will always be used for git commit, not only for TYPO3 projects.
-
-In this case, you can set the template only for the current TYPO3 repository. That means, the command has to be repeated whenever you create a new TYPO3 repository.
-
-.. code-block:: shell
-
-   git config --local commit.template ~/.gitmessage.txt
+This is covered in the Git setup instructions, see :ref:`committemplate`.
 
 Bad summary lines examples vs. good examples
 ============================================

--- a/Documentation/Appendix/Composer.rst
+++ b/Documentation/Appendix/Composer.rst
@@ -1,0 +1,69 @@
+.. include:: ../Includes.txt
+
+.. highlight:: bash
+
+.. _composer:
+
+========
+Composer
+========
+
+About Composer
+==============
+
+Composer is a dependency manager for PHP.
+
+So what it basically does is find packages you have defined to be part of your application (in our case TYPO3). But what
+if these packages rely on other packages as well? This is where composer jumps in and takes care of keeping all these
+packages in sync.
+
+Since we use quite some packages (because why would we invent things ourselves that are already there?) composer is an
+extremely useful tool for us.
+
+.. _install-composer:
+
+Install Composer
+================
+
+Follow the
+installation instructions from https://getcomposer.org. Afterwards, you should
+have a working executable `composer` available.
+
+Verify composer is working::
+
+   $ composer --version
+
+
+.. _composer-commands:
+
+Composer Commands
+=================
+
+Once you have installed Composer, this is the command you should run after you
+clone the Git source and after every `git pull` request or switching branches::
+
+   composer install
+
+But, just follow the :ref:`setup instructions <setup>`, it will walk you through the commands
+in the correct order!
+
+.. _custom-composer-commands:
+
+Custom TYPO3 Composer Commands
+==============================
+
+Some additional composer commands have been added for core development.
+
+Just run::
+
+   composer
+
+to list them. You will see something like:
+
+.. code-block:: none
+
+   gerrit:setup                           Enable all the git hooks needed to make contribution easy
+   gerrit:setup:commitMessageHook:enable  Enable the commit message hook needed for gerrit
+   gerrit:setup:preCommitHook:disable     Disable pre commit hook to run some checks locally
+   gerrit:setup:preCommitHook:enable      Enable pre commit hook to run some checks locally
+

--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -9,7 +9,7 @@ git cheat sheet for Core development
 ====================================
 
 This is a short list of commands. If you are not familiar with the
-workflow yet, make sure you follow the link at the beginning of 
+workflow yet, make sure you follow the link at the beginning of
 each section and read the detailed description.
 
 The following commands assume you are in the working directory of the TYPO3 core repository.
@@ -28,46 +28,7 @@ Clone latest master into current directory::
 Setup
 =====
 
-Details: :ref:`Setting-up-your-Git-environment`
-
-Set username and email in repository configuration (default is `--local` = in current repo .git/config)::
-
-   git config user.name "Your Name"
-   git config user.email "your-email@example.com"
-
-If your username and email is the same for all your projects, set it globally (in home config ~/.gitconfig, active for all git repos)::
-
-   git config --global user.name "Your Name"
-   git config --global user.email "your-email@example.com"
-
-Set autosetuprebase::
-
-   git config branch.autosetuprebase remote
-
-Copy commit-msg hook::
-
-   cp Build/git-hooks/commit-msg .git/hooks/commit-msg
-
-Push to gerrit
-
-* **replace** `<YOUR_TYPO3_USERNAME>` with your Gerrit / typo3.org user name!
-
-::
-
-   git config url."ssh://<YOUR_TYPO3_USERNAME>@review.typo3.org:29418".pushInsteadOf git://git.typo3.org
-
-*Optional*: Set a commit message template::
-
-   git config commit.template ~/.gitmessage.txt
-
-This command uses the file ~/.gitmessage.txt as git message template. 
-For additional information about how to set up a proper commit message
-see :ref:`committemplate`
-
-Show current configuration::
-
-  git config -l
-
+For detailed setup instructions, please see: :ref:`Setting-up-your-Git-environment`
 
 Workflow - common commands
 ==========================
@@ -94,7 +55,7 @@ Stage and commit all changes to already existing commit::
 Push changes to remote master on gerrit (default method)::
 
    git push origin HEAD:refs/publish/master
-   
+
 
 Workflow - drafts
 =================
@@ -104,8 +65,8 @@ Push changes to remote master on gerrit as **draft**::
    git push origin HEAD:refs/drafts/master
 
 
-*When pushing as draft, the pushed patch will only be visible to you 
-and those who you add as a reviewer. It also does not start any 
+*When pushing as draft, the pushed patch will only be visible to you
+and those who you add as a reviewer. It also does not start any
 automated tests or builds on the TYPO3 testing infrastructure.*
 
 .. _cheat-sheet-git-other-branches:
@@ -130,7 +91,7 @@ Checkout 8.7 branch::
 
 
 Long story short: In most cases, **push to master**. The rest is being taken
-care of when time is right.
+care of by core team members!
 
 Push 8.7 branch::
 
@@ -151,7 +112,7 @@ Example commit message for a bugfix:
 .. code-block:: text
 
    [BUGFIX] Subject line
-   
+
    Description
 
    Resolves: #12345

--- a/Documentation/Quickstart/QuickStartCreateAPatch.rst
+++ b/Documentation/Quickstart/QuickStartCreateAPatch.rst
@@ -45,9 +45,19 @@ Quick start: Creating a patch
 
       git config branch.autosetuprebase remote
 
-   Setup commit hook::
+   Setup commit-msg hook::
 
       cp Build/git-hooks/commit-msg .git/hooks/commit-msg
+
+
+   .. tip::
+
+   On Linux / MacOS, instead of copying the commit-msg hook, you can simply run::
+
+      composer gerrit:setup
+
+   This will do all Commit Hook operations for you: copy :file:`commit-msg` and :file:`pre-commit hook`,
+   make them executable etc. For more information see :ref:`commit-hook` and :ref:`composer`.
 
    Push to Gerrit (replace `<YOUR_TYPO3_USERNAME>` here)::
 

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -18,6 +18,7 @@ Prerequisites
 * Make sure, you have cloned the TYPO3 source as described previously in :ref:`setup-typo3-git-clone`::
 
       git clone git://git.typo3.org/Packages/TYPO3.CMS.git .
+      composer install
 
 
 Set username and email
@@ -46,75 +47,35 @@ to set the autosetuprebase option, such that your local commits are always rebas
 
 
 .. _setup-git-commit-hook:
-
-Install your commit hooks
-=========================
-
 .. _git-setup-commit-msg-hook:
 
-commit-msg hook
----------------
+Install Your Commit Hooks
+=========================
 
-.. important::
-   The commit-msg hook is mandatory. It must be installed before you commit
-   your changes. The hook will not prevent you from committing. It will
-   complain about a messed up commit message, though. In case you forgot
-   to write a correct commit message, you can always amend your last commit
-   message to correct it.
+There are two git hooks available for TYPO3 development:
 
+* :ref:`commit-msg-hook`
+* :ref:`pre-commit-hook`
 
-Activate the hook::
+To set them up, do the following:
 
-   # ensure folder exists
-   mkdir -p .git/hooks
+For Linux / MacOS::
 
-   # copy
-   cp Build/git-hooks/commit-msg .git/hooks/commit-msg
+  composer gerrit:setup
 
-   # make executable
-   chmod +x .git/hooks/commit-msg
+This will "install" the :file:`commit-msg` hook and :file:`pre-commit` hook.
 
-.. note::
-   You do not need the mkdir unless the .git/hooks directory doesn't exist. 
-   It does not do any harm to execute it in any case though. 
+For Windows::
 
-You can read about the why and where of this hook :ref:`here <appendix-commit-hook>`.
+  composer gerrit:setup:commitMessageHook:enable
+
+Or use a short form::
+
+  composer composer ge:set:com:enable
 
 
-.. _git-setup-precommithook:
-
-pre-commit hook
----------------
-
-.. important::
-   The pre-commit hook is not supported on Windows.
-
-.. note::
-   The pre-commit hook is optional. It is not required for creating commits,
-   but it will assist you in detecting problems with not correctly formatted
-   files which will later cause the automatic tests to fail.
-
-Again, you can copy the pre-commit hook from the build directory. This is not
-available prior to the 8.7 branch::
-
-   # ensure folder exists
-   mkdir -p .git/hooks
-
-   # copy
-   cp Build/git-hooks/unix+mac/pre-commit .git/hooks/
-
-   # make executable
-   chmod +x .git/hooks/pre-commit
-
-The pre-commit hook will check that all PHP files that will be committed
-conform to the TYPO3 Coding Guidelines. If this is not the case, the
-hook will display an error message. It will not automatically repair
-any files though. You must do this yourself and afterwards amend your
-commit::
-
-   git commit -a --amend
-
-There are scripts available for fixing Coding Guideline issues, see :ref:`cgl-fix-my-commit`.
+This will only install the :file:`commit-msg` hook. The :file:`commit-msg` hook
+is mandatory.
 
 
 Setting up your remote
@@ -123,6 +84,42 @@ Setting up your remote
 You must instruct Git to push to Gerrit_ instead of the original repository. It acts as a kind of facade in front of Git::
 
    git config url."ssh://<YOUR_TYPO3_USERNAME>@review.typo3.org:29418".pushInsteadOf git://git.typo3.org
+
+.. _committemplate:
+
+Setting up a Commit Message Template
+====================================
+
+This is optional!
+
+If you follow these instructions, whenever you create a new commit,
+Git will use the template to create the commit message, which you can
+then modify in your editor. So use this, to make it easier for you to
+fill out the required information.
+
+First, create a file, for example in :file:`~/.gitmessage.txt`.
+
+.. code-block:: none
+
+   [BUGFIX|TASK|FEATURE]
+
+   Resolves: #
+   Releases: master, 9.5
+
+Make Git use this file as a template for the commit message::
+
+   git config commit.template ~/.gitmessage.txt
+
+
+For additional information about how to write a proper commit message
+see :ref:`commitmessage`.
+
+Show Configuration
+==================
+
+Show current configuration::
+
+  git config -l
 
 
 Other resources

--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -20,17 +20,12 @@ Composer
 .. sidebar:: Composer
 
    You can learn a lot more about composer on their website https://getcomposer.org/.
+   Also, look at :ref:`composer` in the Appendix for some
+   information specific to the TYPO3 core contribution toolchain.
 
 Composer is a dependency manager for PHP.
 
-So what it basically does is find packages you have defined to be part of your application (in our case TYPO3). But what
-if these packages rely on other packages as well? This is where composer jumps in and takes care of keeping all these
-packages in sync.
-
-Since we use quite some packages (because why would we invent things ourselves that are already there?) composer is an
-extremely useful tool for us.
-
-Composer is a mandatory tool for setting up your toolchain for TYPO3. Follow the
+Composer is a **mandatory** tool for setting up your toolchain for TYPO3. Follow the
 installation instructions from https://getcomposer.org. Afterwards, you should
 have a working executable `composer` available.
 


### PR DESCRIPTION
- Git setup was covered in setup section and git cheat sheet:
  remove git setup in cheat sheet and just added link
- Commit message template was covered in Appendix, commit message
  rules: move this to git setup section
- The new composer commands gerrit:setup where not yet used in
  the contribution guide. This is now fixed.
- Add new section Composer in Appendix. Move extra information
  there, add information about custom composer commands

Related: #107