### PR TITLE
Replace refs/publish by refs/for in Gerrit push

### DIFF
--- a/Documentation/Appendix/Windows/CloneWithSourcetree.rst
+++ b/Documentation/Appendix/Windows/CloneWithSourcetree.rst
@@ -134,7 +134,7 @@ In the Git Bash window (click Terminal), enter the following commands to set tha
 .. code-block:: bash
 
    git config url."ssh://<username>@review.typo3.org:29418".pushInsteadOf git://git.typo3.org
-   git config remote.origin.push refs/heads/*:refs/publish/*
+   git config remote.origin.push refs/heads/*:refs/for/*
    git config branch.autosetuprebase remote
 
 

--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -137,7 +137,7 @@ Step by step walkthrough
 
    To submit the patch to Gerrit, issue the following command::
 
-      git push origin HEAD:refs/publish/master
+      git push origin HEAD:refs/for/master
 
 
    If Gerrit accepts your push, it responds with the following messages:
@@ -148,7 +148,7 @@ Step by step walkthrough
       remote:   https://review.typo3.org/<gerrit-id>
       remote:
       To ssh://<username>@review.typo3.org:29418/Packages/TYPO3.CMS.git
-       * [new branch]      HEAD -> refs/publish/<release-branch>
+       * [new branch]      HEAD -> refs/for/<release-branch>
 
    You can visit the link to https://review.typo3.org to see your patch in Gerrit.
 

--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -54,7 +54,10 @@ Stage and commit all changes to already existing commit::
 
 Push changes to remote master on gerrit (default method)::
 
-   git push origin HEAD:refs/publish/master
+   git push origin HEAD:refs/for/master
+
+.. note::
+   Pushing to `refs/publish` is deprecated, we now push to `refs/for`.
 
 
 Workflow - drafts
@@ -99,15 +102,15 @@ care of by core team members!
 
 Push 9.5 branch::
 
-   git push origin HEAD:refs/publish/9.5
+   git push origin HEAD:refs/for/9.5
 
 Push 8.7 branch::
 
-   git push origin HEAD:refs/publish/TYPO3_8-7
+   git push origin HEAD:refs/for/TYPO3_8-7
 
 Push 7.6 branch::
 
-   git push origin HEAD:refs/publish/TYPO3_7-6
+   git push origin HEAD:refs/for/TYPO3_7-6
 
 
 Workflow - commit msg

--- a/Documentation/HandlingAPatch/ChangeAPatch.rst
+++ b/Documentation/HandlingAPatch/ChangeAPatch.rst
@@ -49,6 +49,6 @@ This chapter handles improving an existing patch. For creating a new patch, see 
 6. Push your change to Gerrit
 
    Once you are satisfied, push your improved Patch Set to Gerrit::
-     
 
-      git push origin HEAD:refs/publish/master
+
+      git push origin HEAD:refs/for/master

--- a/Documentation/Quickstart/QuickStartCreateAPatch.rst
+++ b/Documentation/Quickstart/QuickStartCreateAPatch.rst
@@ -118,7 +118,7 @@ Quick start: Creating a patch
    Then, commit and push::
 
       git commit -a
-      git push origin HEAD:refs/publish/master
+      git push origin HEAD:refs/for/master
 
 10. Finally, announce your review on Slack
 


### PR DESCRIPTION
Pushing to refs/publish/* is deprecated, use refs/for/* instead.