### PR TITLE
Restructure menu with dividers

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -5,9 +5,9 @@
 .. _core-contrib-quickstart:
 .. _quickstart-create-a-patch:
 
-=======================
-Create & Submit a Patch
-=======================
+==============
+Create a Patch
+==============
 
 **Quick links:**
 

--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -4,9 +4,9 @@
 
 .. _cheat-sheet-git:
 
-====================================
-Git Cheat Sheet for Core Development
-====================================
+===============
+Git Cheat Sheet
+===============
 
 This is a short list of commands. If you are not familiar with the
 workflow yet, make sure you follow the link at the beginning of

--- a/Documentation/CheatSheets/Index.rst
+++ b/Documentation/CheatSheets/Index.rst
@@ -1,3 +1,8 @@
+.. this is currently not included in menu.
+.. the Git cheat sheet is currently directly included in the menu
+
+:orphan:
+
 .. include:: ../Includes.txt
 
 .. _forge-index:

--- a/Documentation/Community/Index.rst
+++ b/Documentation/Community/Index.rst
@@ -1,5 +1,6 @@
 .. include:: ../Includes.txt
 
+.. _introduction:
 .. _how-to-get-help:
 .. _community:
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -36,6 +36,7 @@ TYPO3 Contribution Guide - Core Development
 - :ref:`Git Setup <Setting-up-your-Git-environment>`
 - :ref:`Git Cheat Sheet <cheat-sheet-git>`
 - :ref:`Commit Message Rules <commitmessage>`
+- :ref:`bugreporting-index`
 - :ref:`quickstart-create-a-patch`
 - :ref:`whats_new_in_this_guide`
 
@@ -64,7 +65,7 @@ a GNU/GPL CMS/Framework available from `typo3.org
    Once completed, the Guide becomes a practical reference tool to which a reader can refer
    as needed. Guides offer advice on how best to achieve a given task.
 
-**For Contributors**
+**For Documentation Contributors**
 
    You are welcome to help in improving this guide. Just click on "Edit me on GitHub"
    on the top right to submit your change request.
@@ -84,8 +85,42 @@ a GNU/GPL CMS/Framework available from `typo3.org
 .. toctree::
    :hidden:
 
-   Introduction/Index
+
+
+.. preface: Information about manual
+
+.. toctree::
+   :hidden:
+
+   Introduction/Preface
+
+
+.. introductory chapter
+
+.. toctree::
+   :hidden:
+   :caption: INTRODUCTION
+
+   Community/Index
+   WorkflowExplained/Index
+   Forger/Index
+
+
+.. setup
+
+.. toctree::
+   :hidden:
+   :caption: SETUP
+
    Setup/Index
+
+
+.. howtos
+
+.. toctree::
+   :hidden:
+   :caption: HOWTOS
+
    ReportingAnIssue/Index
    BugfixingAZ/Index
    AddingDocumentation/Index
@@ -93,6 +128,14 @@ a GNU/GPL CMS/Framework available from `typo3.org
    DebuggingTypo3/Index
    HandlingAPatch/Index
    HandlingIssues/TicketWorkflow
-   CheatSheets/Index
+
+
+.. references
+
+.. toctree::
+   :hidden:
+   :caption: REFERENCES
+
+   CheatSheets/Git
    Appendix/Index
    Sitemap/Index

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -1,15 +1,5 @@
+:orphan:
+
 .. include:: ../Includes.txt
 
-.. _introduction:
-
-============
-Introduction
-============
-
-.. toctree::
-   :hidden:
-
-   Preface
-   ../Community/Index
-   ../WorkflowExplained/Index
-   ../Forger/Index
+Please see :ref:`Start page <start>`

--- a/Documentation/ReportingAnIssue/Index.rst
+++ b/Documentation/ReportingAnIssue/Index.rst
@@ -3,9 +3,9 @@
 .. _forge-index:
 .. _bugreporting-index:
 
-=======================
-Report an Issue (Forge)
-=======================
+===============
+Report an Issue
+===============
 
 .. _forge-introduction:
 

--- a/Documentation/WorkflowExplained/Index.rst
+++ b/Documentation/WorkflowExplained/Index.rst
@@ -3,7 +3,7 @@
 .. _workflow-explained:
 
 ============================
-TYPO3 Contribution explained
+TYPO3 Contribution Explained
 ============================
 
 Ok, so you want to overview first, that's fine. Actually, it's a brilliant idea to understand the concept first to help


### PR DESCRIPTION
- use dividers (captions) to structure menu (INTRODUCTION, SETUP, ...)
- keep menu items short
- move git cheat sheet to top level menu (people have to click less)
  the file location stays the same!