### PR TITLE
Update SettingUpTypo3Ddev.rst

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -134,7 +134,7 @@ Setup your TYPO3 installation
 
 Now load the URL as shown by `ddev start` in your browser with the path
 `/typo3` appended to it. Typically this will be
-http://t3master.ddev.local/typo3.
+http://t3master.ddev.site/typo3.
 
 You will now be guided through the basic installation steps by TYPO3.
 


### PR DESCRIPTION
Example link updated for current ddev version. ddev currently uses site as local TLD and not local.