### PR TITLE
Replaced wrong method (func_get_args -> func_num_args)

### DIFF
--- a/Documentation/Appendix/HowToDeprecateThings.rst
+++ b/Documentation/Appendix/HowToDeprecateThings.rst
@@ -67,7 +67,7 @@ and remove an unused argument, use :php:`func_get_args()` for arguments existenc
 
    public function TS_AtagToAbs($value)
    {
-      if (func_get_args() > 1) {
+      if (func_num_args() > 1) {
          trigger_error('Second argument of TS_AtagToAbs() is not in use and is removed, however the argument in the callers code can be removed without side-effects.', E_USER_DEPRECATED);
       }
       // ...

--- a/Documentation/Appendix/HowToDeprecateThings.rst
+++ b/Documentation/Appendix/HowToDeprecateThings.rst
@@ -59,7 +59,7 @@ Deprecate method arguments
 
 If you want to deprecate method arguments, check for argument existence and
 trigger an error the same way you would for a method. If you want to deprecate
-and remove an unused argument, use :php:`func_get_args()` for arguments existence
+and remove an unused argument, use :php:`func_get_args()` or :php:`func_num_args()`
 (see example below):
 
 .. code-block:: php


### PR DESCRIPTION
Because `func_get_args` returns an array, probably `func_num_args` is what should have been documented.