### PR TITLE
Fix index

### DIFF
--- a/Documentation/Account/GerritAccount.rst
+++ b/Documentation/Account/GerritAccount.rst
@@ -1,11 +1,12 @@
 .. include:: ../Includes.txt
 
-.. _GerritAccount:
-.. _gerrit-ssh:
 
 .. index::
    single: Tools; Gerrit
    single: Account; Gerrit
+
+.. _GerritAccount:
+.. _gerrit-ssh:
 
 =======================
 Setting up Gerrit (ssh)

--- a/Documentation/Account/Index.rst
+++ b/Documentation/Account/Index.rst
@@ -1,11 +1,12 @@
 .. include:: ../Includes.txt
 
-.. _TYPO3-Guide-ContributionWorkflow-Account:
-.. _setting-up-your-account:
 
 .. index::
    single: Account; Setup
    single: Account
+
+.. _TYPO3-Guide-ContributionWorkflow-Account:
+.. _setting-up-your-account:
 
 ========================
 Setting up Your Accounts

--- a/Documentation/Account/Slack.rst
+++ b/Documentation/Account/Slack.rst
@@ -13,11 +13,11 @@ it is the projects chosen platform for communication.
 It is mandatory to create a typo3.org account, before you
 can join the TYPO3 Slack workspace.
 
-.. _register-for-slack-account:
-
 .. index::
    single: Account; Slack Registration
    single: Tools; Slack Registration
+
+.. _register-for-slack-account:
 
 Register for Slack account
 --------------------------

--- a/Documentation/Account/TYPO3Account.rst
+++ b/Documentation/Account/TYPO3Account.rst
@@ -1,10 +1,10 @@
 .. include:: ../Includes.txt
 
-.. _TYPO3Account:
-
 .. index::
    single: Account; Typo3.org
    single: Typo3.org
+
+.. _TYPO3Account:
 
 ==============================
 Signup for a TYPO3.org Account

--- a/Documentation/AddingDocumentation/Index.rst
+++ b/Documentation/AddingDocumentation/Index.rst
@@ -1,10 +1,10 @@
 .. include:: ../Includes.txt
 
-.. _Bugfixing-Adding-documentation:
-.. _Adding-documentation:
-
 .. index::
    single: Documentation Contribution; Adding Documentation
+
+.. _Bugfixing-Adding-documentation:
+.. _Adding-documentation:
 
 =================
 Add Documentation
@@ -25,11 +25,11 @@ and documentation for
 `system extensions <https://docs.typo3.org/typo3cms/SystemExtensions/Index.html>`__
 is maintained in the core.
 
-.. _changelog:
-
 .. index::
    single: Documentation Contribution Workflow; Add Changelog
    single: Changelog; Add Entries
+
+.. _changelog:
 
 Changelog
 =========
@@ -81,10 +81,10 @@ need to go into :file:`typo3/sysext/core/Documentation/Changelog/master/`.
 
 Choose one which fits your patch:
 
-.. _documenting-changelog-breaking-changes:
-
 .. index::
    single: Documentation Contribution Workflow; Breaking Changes
+
+.. _documenting-changelog-breaking-changes:
 
 Breaking Changes
 ~~~~~~~~~~~~~~~~
@@ -105,10 +105,10 @@ that may break extensions if they use this part.
    working again. Explicitly mention if no migration is possible.
 
 
-.. _documenting-changelog-deprecations:
-
 .. index::
    single: Documentation Contribution Workflow; Deprecations
+
+.. _documenting-changelog-deprecations:
 
 Deprecations
 ~~~~~~~~~~~~
@@ -129,10 +129,10 @@ for a planned removal. See more information: :ref:`Deprecations <deprecations>`
    working again. Explicitly mention if no migration is possible.
 
 
-.. _documenting-changelog-features:
-
 .. index::
    single: Documentation Contribution Workflow; Features
+
+.. _documenting-changelog-features:
 
 Features
 ~~~~~~~~
@@ -146,10 +146,10 @@ A patch adds new functionality.
 #. **Impact** - how users are affected by this new feature.
 
 
-.. _documenting-changelog-important-information:
-
 .. index::
    single: Documentation Contribution Workflow; Important Information
+
+.. _documenting-changelog-important-information:
 
 Important Information
 ~~~~~~~~~~~~~~~~~~~~~
@@ -159,21 +159,19 @@ important enough to require a Changelog entry.
 
 #. **Description** - describe what is so important it needed an rst snippet
 
-.. _changelog-check-rst:
-
 .. index::
    single: Documentation Contribution Workflow; Checking reST Files
    single: Tools; Checking reST Files
    single: Changelog; Checking
+
+.. _changelog-check-rst:
 
 Check Your `rst` File
 ---------------------
 
 When your change is finished, you can run the following script to check that
 your rst file is ok. The script will check all files in
-:file:`typo3/sysext/core/Documentation/Changelog`.
-
-::
+:file:`typo3/sysext/core/Documentation/Changelog`::
 
    Build/Scripts/validateRstFiles.php
 
@@ -187,13 +185,12 @@ be rendered correctly, do one or more of the following:
 * Use an editor or IDE that properly supports reST and shows errors
 * Render the Changelog locally with docker as explained in the next section
 
-
-.. _render-the-changelog:
-
 .. index::
    single: Documentation Contribution Workflow; Rendering Changelog
    single: Tools; Rendering Changelog
    single: Changelog; Rendering
+
+.. _render-the-changelog:
 
 Render the Changelog
 --------------------
@@ -249,10 +246,10 @@ Once a new TYPO3 release comes out, the main documentation (e.g. :ref:`t3coreapi
 
 The procedure is documented in :ref:`h2document:update-docs`.
 
-.. _documenting-system-extensions:
-
 .. index::
    single: Documentation Contribution Workflow; Documenting System Extensions
+
+.. _documenting-system-extensions:
 
 Document System Extensions
 ==========================

--- a/Documentation/Appendix/Aliases.rst
+++ b/Documentation/Appendix/Aliases.rst
@@ -1,11 +1,10 @@
 .. include:: ../Includes.txt
 
-
-.. _aliases:
-
 .. index::
    single: Git; Aliases
    single: Aliases
+
+.. _aliases:
 
 =====================
 Aliases & Git Aliases

--- a/Documentation/Appendix/Cgl.rst
+++ b/Documentation/Appendix/Cgl.rst
@@ -1,11 +1,10 @@
 .. include:: ../Includes.txt
 
-
-.. _appendix-cgl:
-
 .. index::
    single: CGL
    single: Coding Guidelines
+
+.. _appendix-cgl:
 
 =================
 Coding Guidelines

--- a/Documentation/Appendix/CglFixMyCommit.rst
+++ b/Documentation/Appendix/CglFixMyCommit.rst
@@ -1,11 +1,10 @@
 .. include:: ../Includes.txt
 
-
-.. _cgl-fix-my-commit:
-
 .. index::
    single: CGL; Fix
    single: CGL; Troubleshoot
+
+.. _cgl-fix-my-commit:
 
 ==============
 cglFixMyCommit

--- a/Documentation/Appendix/CommitHook.rst
+++ b/Documentation/Appendix/CommitHook.rst
@@ -1,22 +1,22 @@
 .. include:: ../Includes.txt
 
-.. _appendix-commit-hook:
-.. _commit-hook:
-
 .. index::
    single: Git; Hooks
    single: Git Hooks
+
+.. _appendix-commit-hook:
+.. _commit-hook:
 
 ============
 Commit Hooks
 ============
 
-.. _why-a-commit-msg-hook:
-.. _commit-msg-hook:
-
 .. index::
    single: Git; commit-msg Hook
    single: commit-msg Hook
+
+.. _why-a-commit-msg-hook:
+.. _commit-msg-hook:
 
 
 `commit-msg` Hook
@@ -41,14 +41,12 @@ If the commit-msg hook finds errors in your commit-msg, you can try again, by am
    git commit --amend
 
 
-
-
-.. _why-pre-commit-hook:
-.. _pre-commit-hook:
-
 .. index::
    single: Git; pre-commit Hook
    single: pre-commit Hook
+
+.. _why-pre-commit-hook:
+.. _pre-commit-hook:
 
 `pre-commit` Hook
 =================
@@ -69,12 +67,11 @@ commit::
 
 
 
-.. _post-checkout-for-composer-update:
-
 .. index::
    single: Git; post-checkout Hook
    single: post-checkout Hook
 
+.. _post-checkout-for-composer-update:
 
 Post-checkout hook for composer install
 ======================================

--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -1,10 +1,10 @@
 .. include:: ../Includes.txt
 
-.. _commitmessage:
-
 .. index::
    single: Git; Commit Message Rules
    single: Commit Message Rules
+
+.. _commitmessage:
 
 ===================================
 Commit Message rules for TYPO3 CMS

--- a/Documentation/Appendix/Composer.rst
+++ b/Documentation/Appendix/Composer.rst
@@ -2,11 +2,10 @@
 
 .. highlight:: bash
 
-.. _composer:
-
 .. index::
    single: Composer
 
+.. _composer:
 
 ========
 Composer
@@ -24,10 +23,10 @@ packages in sync.
 Since we use quite some packages (because why would we invent things ourselves that are already there?) composer is an
 extremely useful tool for us.
 
-.. _install-composer:
-
 .. index::
    single: Composer; Install Composer
+
+.. _install-composer:
 
 Install Composer
 ================
@@ -55,11 +54,10 @@ But, just follow the :ref:`setup instructions <setup>`, it will walk you through
 in the correct order!
 
 
-
-.. _custom-composer-commands:
-
 .. index::
    single: Composer; Custom Composer Commands
+
+.. _custom-composer-commands:
 
 Custom TYPO3 Composer Commands
 ==============================

--- a/Documentation/Appendix/HowToDeprecateThings.rst
+++ b/Documentation/Appendix/HowToDeprecateThings.rst
@@ -1,9 +1,9 @@
 .. include:: ../Includes.txt
 
-.. _deprecations:
-
 .. index::
    single: Deprecation
+
+.. _deprecations:
 
 ========================================================================
 How to deprecate classes, methods, arguments and hooks in the TYPO3 core
@@ -17,10 +17,10 @@ or change functionality in the TYPO3 core, it has to be deprecated first.
 Here is how:
 
 
-.. _deprecate-class:
-
 .. index::
    single: Deprecation; Deprecate a class
+
+.. _deprecate-class:
 
 Deprecate a class
 =================
@@ -29,10 +29,10 @@ Deprecate a class
  * Deprecate the constructor - see next section about deprecating a method
 
 
-.. _deprecate-method:
-
 .. index::
    single: Deprecation; Deprecate a method
+
+.. _deprecate-method:
 
 Deprecate method
 ================
@@ -49,10 +49,10 @@ Deprecate method
    );
 
 
-.. _deprecate-method-arguments:
-
 .. index::
    single: Deprecation; Deprecate method arguments
+
+.. _deprecate-method-arguments:
 
 Deprecate method arguments
 ==========================
@@ -74,10 +74,10 @@ and remove an unused argument, use :php:`func_get_args()` or :php:`func_num_args
    }
 
 
-.. _deprecate-hooks:
-
 .. index::
    single: Deprecation; Deprecate a hook
+
+.. _deprecate-hooks:
 
 Deprecate a hook
 ================
@@ -110,10 +110,10 @@ before the hook call:
    }
 
 
-.. _deprecate-used-methods:
-
 .. index::
    single: Deprecation; Deprecate methods still called by the core
+
+.. _deprecate-used-methods:
 
 Deprecate methods still called by the TYPO3 Core
 ================================================

--- a/Documentation/Appendix/IdePhpStormGerritPlugin.rst
+++ b/Documentation/Appendix/IdePhpStormGerritPlugin.rst
@@ -1,9 +1,9 @@
 .. include:: ../Includes.txt
 
-.. _phpstorm-gerritplugin:
-
 .. index::
    single: PhpStorm; Gerrit Plugin
+
+.. _phpstorm-gerritplugin:
 
 =======================
 PhpStorm: Gerrit Plugin

--- a/Documentation/Appendix/IdePhpStormSetup.rst
+++ b/Documentation/Appendix/IdePhpStormSetup.rst
@@ -1,12 +1,10 @@
 .. include:: ../Includes.txt
 
-
-.. _phpstorm-setup:
-
 .. index::
    single: PhpStorm; PhpStorm Setup
    single: Setup; PhpStorm
 
+.. _phpstorm-setup:
 
 ===============
 PhpStorm: Setup
@@ -85,11 +83,10 @@ You can find more information on the :ref:`Coding Guidelines section in the Appe
 <appendix-cgl>`.
 
 
-
-.. _phpstorm-setup-plugins:
-
 .. index::
    single: PhpStorm; PhpStorm Plugins
+
+.. _phpstorm-setup-plugins:
 
 Plugins for PhpStorm
 ====================
@@ -143,11 +140,11 @@ Optional Plugins
   <https://plugins.jetbrains.com/plugin/8098-typo3-xliff-utility>`__
 
 
-.. _phpstorm-setup-testing:
-
 .. index::
    single: PhpStorm; Setup Testing Framework
    single: Testing; Setup PhpStorm
+
+.. _phpstorm-setup-plugins:
 
 Setting up  PhpStorm for the Testing Framework
 ==============================================

--- a/Documentation/Appendix/Linux/SSHKeyUnix.rst
+++ b/Documentation/Appendix/Linux/SSHKeyUnix.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _ssh-key-unix:
-
 .. index::
    single: Linux; SSH Key
    single: SSH Key; Linux
+
+.. _ssh-key-unix:
 
 =======================================
 Creating a SSH Public Key on Unix/Linux

--- a/Documentation/Appendix/Linux/SettingUpTypo3ManuallyLinux.rst
+++ b/Documentation/Appendix/Linux/SettingUpTypo3ManuallyLinux.rst
@@ -2,11 +2,11 @@
 
 .. highlight:: bash
 
-.. _setting-up-typo3-manually-linux:
-
 .. index::
    single: Linux
    single: Setup; Linux
+
+.. _setting-up-typo3-manually-linux:
 
 =====================================
 Setting up TYPO3 manually under Linux
@@ -86,9 +86,7 @@ Create a basic site for your installation
 
 Edit a sitefile, e.g. `/etc/apache2/sites-available/t3coredev.conf`
 
-make sure it will point to the correct htdocs directory:
-
-::
+make sure it will point to the correct htdocs directory::
 
    <VirtualHost *:80>
       ServerAdmin youremail@yourdomain
@@ -99,9 +97,7 @@ make sure it will point to the correct htdocs directory:
    </VirtualHost>
 
 
-Enable it
-
-::
+Enable it::
 
    sudo a2ensite t3coredev
    sudo service apache2 reload

--- a/Documentation/Appendix/OSX/GitTower.rst
+++ b/Documentation/Appendix/OSX/GitTower.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _gittower-osx:
-
 .. index::
    single: Git Tower
    single: Git; Git Tower
+
+.. _gittower-osx:
 
 ======================
 Working with Git Tower

--- a/Documentation/Appendix/OSX/Index.rst
+++ b/Documentation/Appendix/OSX/Index.rst
@@ -1,9 +1,9 @@
 .. include:: ../../Includes.txt
 
-.. _appendix-osx:
-
 .. index::
    single: OS X
+
+.. _appendix-osx:
 
 OS X help
 ===============

--- a/Documentation/Appendix/OSX/InstallComposer.rst
+++ b/Documentation/Appendix/OSX/InstallComposer.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _osx-composer:
-
 .. index::
    single: OS X; Composer installation
    single: Composer installation; OS X
+
+.. _osx-composer:
 
 =======================
 COMPOSER install on OSX

--- a/Documentation/Appendix/OSX/InstallGrunt.rst
+++ b/Documentation/Appendix/OSX/InstallGrunt.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _osx-grunt:
-
 .. index::
    single: OS X; Grunt installation
    single: Grunt installation; OS X
+
+.. _osx-grunt:
 
 ====================
 GRUNT install on OSX

--- a/Documentation/Appendix/OSX/InstallNpm.rst
+++ b/Documentation/Appendix/OSX/InstallNpm.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _osx-npm:
-
 .. index::
    single: OS X; Yarn installation
    single: Yarn installation; OS X
+
+.. _osx-npm:
 
 ===================
 Yarn install on OSX

--- a/Documentation/Appendix/OSX/SSHKeyOSX.rst
+++ b/Documentation/Appendix/OSX/SSHKeyOSX.rst
@@ -2,12 +2,11 @@
 
 .. highlight:: bash
 
-.. _ssh-key-osx:
-
 .. index::
    single: OS X; SSH Key
    single: SSH Key; OS X
 
+.. _ssh-key-osx:
 
 ================================
 Creating a SSH Public Key on OSX

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -2,12 +2,13 @@
 
 .. highlight:: bash
 
-.. _ddev:
-.. _settting-up-typo3-with-ddev:
 
 .. index::
    single: DDEV
    single: Setup; DDEV
+
+.. _ddev:
+.. _settting-up-typo3-with-ddev:
 
 ==========================
 Setting up TYPO3 with DDEV
@@ -46,10 +47,7 @@ In order to be able to build some assets (e.g. css, js files) you need to have `
 Clone TYPO3
 ===========
 
-Create a clone of the TYPO3 git repository as described in :ref:`git-clone`.
-
-
-::
+Create a clone of the TYPO3 git repository as described in :ref:`git-clone`::
 
    mkdir t3master
    cd t3master
@@ -66,11 +64,12 @@ Configure DDEV
    ddev config
 
 
-In order to change the PHP version, edit the configuration file `.ddev/config.yaml`. See supported version here: https://typo3.org/cms/roadmap/
-
-::
+In order to change the PHP version, edit the configuration file `.ddev/config.yaml`::
 
    php_version: "7.3"
+
+
+See supported version here: https://typo3.org/cms/roadmap/
 
 Start DDEV
 ==========
@@ -85,9 +84,7 @@ Start DDEV
 Install dependencies via composer
 =================================
 
-This runs inside the container and thus uses your configured PHP version.
-
-::
+This runs inside the container and thus uses your configured PHP version::
 
    ddev composer install
 
@@ -96,16 +93,12 @@ This runs inside the container and thus uses your configured PHP version.
 Check for database credentials
 ==============================
 
-Let DDEV dump information:
-
-::
+Let DDEV dump information::
 
    ddev describe
 
 You will need username, password, Database name, host and port of the
-MySQL credentials to setup your TYPO3 installation, e.g.
-
-::
+MySQL credentials to setup your TYPO3 installation, e.g.::
 
    MySQL Credentials
    -----------------
@@ -122,9 +115,7 @@ FIRST_INSTALL
    Creating FIRST_INSTALL is probably not necessary. Check to see if the database exists.
    ddev describe should give you enough information for that.
 
-Now, create a file `FIRST_INSTALL`:
-
-::
+Now, create a file `FIRST_INSTALL`::
 
    touch FIRST_INSTALL
 

--- a/Documentation/Appendix/Slack.rst
+++ b/Documentation/Appendix/Slack.rst
@@ -32,11 +32,13 @@ As always, make sure to follow the `Code of conduct <https://typo3.org/community
 or the short form: **be nice, be helpful!**
 
 
-.. _botty:
+
 
 .. index::
    single: Slack; Botty
    single: Botty
+
+.. _botty:
 
 Botty on Slack
 ~~~~~~~~~~~~~~

--- a/Documentation/Appendix/Windows/CloneWithSourcetree.rst
+++ b/Documentation/Appendix/Windows/CloneWithSourcetree.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _windows-clonewithsourcetree:
-
 .. index::
    single: Windows; SourceTree
    single: SourceTree
+
+.. _windows-clonewithsourcetree:
 
 ==================================
 Cloning with SourceTree on Windows

--- a/Documentation/Appendix/Windows/GitForWindows.rst
+++ b/Documentation/Appendix/Windows/GitForWindows.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _git-for-windows:
-
 .. index::
    single: Windows; Git
    single: Git; Windows
+
+.. _git-for-windows:
 
 ============================
 Working with Git for Windows

--- a/Documentation/Appendix/Windows/SSHKeyWindows.rst
+++ b/Documentation/Appendix/Windows/SSHKeyWindows.rst
@@ -1,11 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _ssh-key-win:
-
 .. index::
    single: Windows; SSH Key
    single: SSH Key; Windows
 
+.. _ssh-key-win:
 
 ====================================
 Creating a SSH Public Key on Windows

--- a/Documentation/Appendix/Windows/Troubleshooting.rst
+++ b/Documentation/Appendix/Windows/Troubleshooting.rst
@@ -1,10 +1,10 @@
 .. include:: ../../Includes.txt
 
-.. _troubleshooting-for-windows:
-
 .. index::
    single: Windows; Troubleshooting
    single: Troubleshooting; Windows
+
+.. _troubleshooting-for-windows:
 
 ============================
 Troubleshooting for Windows

--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -1,12 +1,13 @@
 .. include:: ../Includes.txt
 .. highlight:: shell
 
+.. index::
+   single: Code Contribution Workflow; Create Patch
+
 .. _Fixing-a-bug-A-Z:
 .. _core-contrib-quickstart:
 .. _quickstart-create-a-patch:
 
-.. index::
-   single: Code Contribution Workflow; Create Patch
 
 ==============
 Create a Patch

--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -2,11 +2,11 @@
 
 .. highlight:: bash
 
-.. _cheat-sheet-git:
-
 .. index::
    single: Git; Git Cheat Sheet
    single: Cheat Sheets; Git Cheat Sheet
+
+.. _cheat-sheet-git:
 
 ===============
 Git Cheat Sheet

--- a/Documentation/Community/Index.rst
+++ b/Documentation/Community/Index.rst
@@ -13,11 +13,11 @@ to the TYPO3 codebase. However, you might run into problems. If this is
 the case, there are several possibilities to get help. Do not hesitate
 to ask others, if you can't find the information you need.
 
-.. _slack:
-
 .. index::
    single: Tools; Slack
    single: Slack
+
+.. _slack:
 
 Slack
 =====
@@ -53,12 +53,12 @@ you the opportunity to ask questions and get help. In any case,
 read the event description and if in doubt, contact the person
 listed in the event description.
 
-.. _typo3-gmbh-review-friday:
-
 .. index::
    single: Events; Review Friday
    single: Review Friday
    single: Review; Review Friday
+
+.. _typo3-gmbh-review-friday:
 
 TYPO3 GmbH Review Friday
 ------------------------
@@ -80,12 +80,12 @@ at the `TYPO3 GmbH headquarters <https://typo3.com/contact/>`__.
 Search for the next Review Friday on `Events on typo3.org <https://typo3.org/community/events/>`__
 and look at the event description for further information.
 
-.. _code-sprints:
-
 .. index::
    single: Events; Code Sprints
    single: Code Sprints
    single: Sprints
+
+.. _code-sprints:
 
 Code Sprints
 ------------
@@ -99,11 +99,11 @@ Look for the next Code Sprints on the `Events page on typo3.org
 In the event description you should also find information about reimbursement and other
 information. You will usually need to signup for the event.
 
-.. _typo3-developer-days:
-
 .. index::
    single: Events; Developer Days
    single: Developer Days
+
+.. _typo3-developer-days:
 
 TYPO3 Developer Days
 --------------------

--- a/Documentation/DebuggingTypo3/Index.rst
+++ b/Documentation/DebuggingTypo3/Index.rst
@@ -8,11 +8,11 @@
 Debug TYPO3
 ===========
 
-.. _debugging-with-phpstorm-and-xdebug:
-
 .. index::
    single: Tools; Debugging With PhpStorm and Xdebug
    single: Debugging; With PhpStorm and Xdebug
+
+.. _debugging-with-phpstorm-and-xdebug:
 
 Debugging With PhpStorm and Xdebug
 ==================================

--- a/Documentation/Forger/Index.rst
+++ b/Documentation/Forger/Index.rst
@@ -1,10 +1,10 @@
 .. include:: ../Includes.txt
 
-.. _forger-index:
-
 .. index::
    single: Tools; Forger
    single: Forger
+
+.. _forger-index:
 
 ======================
 Introduction to Forger

--- a/Documentation/HandlingAPatch/Backporting.rst
+++ b/Documentation/HandlingAPatch/Backporting.rst
@@ -1,10 +1,10 @@
 .. include:: ../Includes.txt
 
-.. _lifeOfAPatch-backport:
-
 .. index::
    single: Gerrit; Backport a Change
    single: Backport a Change
+
+.. _lifeOfAPatch-backport:
 
 ===================================
 Backport a change to other branches

--- a/Documentation/HandlingAPatch/ChangeAPatch.rst
+++ b/Documentation/HandlingAPatch/ChangeAPatch.rst
@@ -3,12 +3,12 @@
 
 .. highlight:: bash
 
-.. _lifeOfAPatch-improve-patch:
-
 .. index::
    single: Code Contribution Workflow; Uploading new Patch Set
    single: Git; Push
    single: Git; Upload new Patch Set
+
+.. _lifeOfAPatch-improve-patch:
 
 ======================
 Upload a new Patch Set

--- a/Documentation/HandlingAPatch/CherryPick.rst
+++ b/Documentation/HandlingAPatch/CherryPick.rst
@@ -2,11 +2,11 @@
 
 .. highlight:: bash
 
-.. _cherry-pick-a-patch:
-
 .. index::
    single: Code Contribution Workflow; Cherry pick a patch
    single: Git; Cherry pick a patch
+
+.. _cherry-pick-a-patch:
 
 ===================
 Cherry-pick a patch

--- a/Documentation/HandlingAPatch/FindAReview.rst
+++ b/Documentation/HandlingAPatch/FindAReview.rst
@@ -1,9 +1,9 @@
 .. include:: ../Includes.txt
 
-.. _Find-a-review:
-
 .. index::
    single: Code Contribution Workflow; Finding Reviews
+
+.. _Find-a-review:
 
 =======================
 Find a review on Gerrit
@@ -12,11 +12,11 @@ Find a review on Gerrit
 For finding an existing review (patch), there are several possibilities. Use whatever
 is most convenient for you or what fits your needs.
 
-.. _forger:
-
 .. index::
    single: Tools; Forger Finding Reviews
    single: Review; Finding Reviews
+
+.. _forger:
 
 Forger
 ======
@@ -45,11 +45,13 @@ If you are in any way involved in the review (e.g. you are author,
 reviewer or you made changes), you will get a notification about
 it to your email adress. The notification contains a link.
 
-.. _gerrit-your-changes:
+
 
 .. index::
    single: Tools; Gerrit Your Changes
    single: Review; Own Changes
+
+.. _gerrit-your-changes:
 
 Gerrit: Your Changes
 ====================
@@ -60,11 +62,13 @@ and select Your: Changes.
 .. image:: _assets/gerrit-your-patches.png
    :class: with-shadow
 
-.. _gerrit-open-changes:
+
 
 .. index::
    single: Tools; Gerrit Open Changes
    single: Review; Open Changes
+
+.. _gerrit-open-changes:
 
 Gerrit: Open Changes
 ====================
@@ -72,11 +76,13 @@ Gerrit: Open Changes
 Select `Changes : Open <https://review.typo3.org/q/status:open>`__ to
 get the latest changes or changes with recent modifications.
 
-.. _gerrit-search:
+
 
 .. index::
    single: Tools; Gerrit Search
    single: Review; Search
+
+.. _gerrit-search:
 
 Gerrit: Search
 ==============

--- a/Documentation/HandlingAPatch/GerritBasics.rst
+++ b/Documentation/HandlingAPatch/GerritBasics.rst
@@ -1,17 +1,17 @@
 .. include:: ../Includes.txt
 
 
-.. _Working-with-Gerrit:
+
 
 .. index::
    single: Tools; Gerrit Introduction
+
+.. _Working-with-Gerrit:
 
 ======================
 Introduction to Gerrit
 ======================
 
-
-.. This text has been moved from Gerrit/Index.rst
 
 Gerrit is a web based code review and project management tool for Git based projects.
 
@@ -20,10 +20,11 @@ TYPO3's Gerrit interface is located at https://review.typo3.org.
 Gerrit handles the review process and is a gatekeeper in front of the official TYPO3 Git repository on git.typo3.org. Pushing to git.typo3.org repository is not allowed for anybody, instead every change has to pass a review process in Gerrit, which later pushes the change to the repository.
 
 
-.. _Gerrit-Overview-of-the-UI:
 
 .. index::
    single: Tools; Gerrit Ui
+
+.. _Gerrit-Overview-of-the-UI:
 
 Overview of the UI
 ==================

--- a/Documentation/HandlingAPatch/Index.rst
+++ b/Documentation/HandlingAPatch/Index.rst
@@ -1,10 +1,11 @@
 .. include:: ../Includes.txt
 
-.. _lifeOfAPatch:
-.. _improving-a-patch:
 
 .. index::
    single: Code Contribution Workflow; Handle and Improve a Patch
+
+.. _lifeOfAPatch:
+.. _improving-a-patch:
 
 ===================================
 Handle and Improve a Patch (Gerrit)

--- a/Documentation/HandlingAPatch/Rebase.rst
+++ b/Documentation/HandlingAPatch/Rebase.rst
@@ -1,17 +1,17 @@
 .. include:: ../Includes.txt
 
-.. _rebase:
+
 
 .. index::
    single: Code Contribution Workflow; Rebasing
    single: Git; Rebase
 
+.. _rebase:
+
 ======
 Rebase
 ======
 
-
-.. include:: ../_includes/NewPageInfo.rst.txt
 
 .. _rebase-intro:
 

--- a/Documentation/HandlingAPatch/ResolveMergeConflicts.rst
+++ b/Documentation/HandlingAPatch/ResolveMergeConflicts.rst
@@ -9,10 +9,12 @@ Resolve Merge conflicts
 
 .. include:: ../_includes/NewPageInfo.rst.txt
 
-.. _what-are-merge-conflicts:
+
 
 .. index::
    single: Git; What are Merge conflicts
+
+.. _what-are-merge-conflicts:
 
 What are merge conflicts?
 =========================
@@ -130,10 +132,12 @@ some way.
 See next section :ref:`how-to-resolve-merge-conflicts` for more information about
 resolving merge conflicts.
 
-.. _how-to-resolve-merge-conflicts:
+
 
 .. index::
    single: Git; How to resolve Merge conflicts
+
+.. _how-to-resolve-merge-conflicts:
 
 How to resolve conflicts?
 =========================

--- a/Documentation/HandlingAPatch/Revert.rst
+++ b/Documentation/HandlingAPatch/Revert.rst
@@ -1,10 +1,12 @@
 .. include:: ../Includes.txt
 
-.. _lifeOfAPatch-Reverting-Patches:
+
 
 .. index::
    single: Gerrit; Revert a Change
    single: Revert a Change
+
+.. _lifeOfAPatch-Reverting-Patches:
 
 ==============
 Revert patches

--- a/Documentation/HandlingAPatch/Review.rst
+++ b/Documentation/HandlingAPatch/Review.rst
@@ -61,17 +61,17 @@ Otherwise throw the changes away, to bring your repository back to a clean state
    git reset --hard origin/master
 
 
-.. _Gerrit-Commenting-files:
+
 
 .. index::
    single: Review; Comment Files
    single: Gerrit; Comment Files
    single: Comment Files
 
+.. _Gerrit-Commenting-files:
+
 Comment files
 =============
-
-.. This section was moved from Gerrit/Index.rst
 
 If you spotted a mistake in any file, you should provide the author with a useful clue where the mistake has been made.
 One way would be to simply note the filename and line number in the central comment box. But this would be cumbersome and
@@ -92,12 +92,12 @@ to use the **Reply Button** to send them all (ideally with a vote indicating how
 
 
 
-.. _gerrit-voting:
-
 .. index::
    single: Review; Vote
    single: Gerrit; Vote
    single: Vote
+
+.. _gerrit-voting:
 
 Vote
 ====

--- a/Documentation/HandlingIssues/TicketWorkflow.rst
+++ b/Documentation/HandlingIssues/TicketWorkflow.rst
@@ -1,10 +1,12 @@
 .. include:: ../Includes.txt
 
-.. _issue-workflow:
+
 
 .. index::
    single: Forge; Issue Workflow
    single: Issue Workflow
+
+.. _issue-workflow:
 
 ======================
 Issue Workflow (Forge)

--- a/Documentation/ReportingAnIssue/Index.rst
+++ b/Documentation/ReportingAnIssue/Index.rst
@@ -1,20 +1,23 @@
 .. include:: ../Includes.txt
 
-.. _forge-index:
-.. _bugreporting-index:
 
 .. index::
    single: Forge; Report an Issue
    single: Issue; Report an Issue
 
+.. _forge-index:
+.. _bugreporting-index:
+
 ===============
 Report an Issue
 ===============
 
-.. _forge-introduction:
+
 
 .. index::
    single: Tools; Forge
+
+.. _forge-introduction:
 
 Introduction to Forge
 =====================
@@ -30,10 +33,10 @@ When you want to report a bug or suggest a new feature, go to the
 
 
 
-.. _searching-for-existing-issues:
-
 .. index::
    single: Issue Reporting Workflow; Searching for Issues
+
+.. _searching-for-existing-issues:
 
 Searching for Existing Issues
 =============================
@@ -47,10 +50,10 @@ easy to find existing issues. Filters are located on the the left hand
 side of the navigation menu. You can use this feature to help refine searches.
 
 
-.. _identify-the-issue:
-
 .. index::
    single: Issue Reporting Workflow; Identifying
+
+.. _identify-the-issue:
 
 Identify the Issue
 ==================
@@ -85,11 +88,11 @@ Talk to the core team
 
 
 
-.. _create-an-issue:
-
 .. index::
    single: Issue Reporting Workflow; Creation
    single: Forge; Create an Issue
+
+.. _create-an-issue:
 
 Create an issue
 ===============
@@ -121,10 +124,12 @@ The others are mostly for internal organization (like **Stories** and **Epics**)
 and things which aren't really a feature or a bug... they are just **Tasks**
 somebody needs to take care of.
 
-.. _subject:
+
 
 .. index::
    single: Issue; Subject
+
+.. _subject:
 
 Subject
 -------
@@ -145,10 +150,11 @@ Good example:
    JS error in Internet Explorer when inserting record in list module.
 
 
-.. _description:
 
 .. index::
    single: Issue; Description
+
+.. _description:
 
 Description
 -----------
@@ -176,20 +182,23 @@ Be polite.
    Always.
 
 
-.. _category:
 
 .. index::
    single: Issue; Category
+
+.. _category:
 
 Category
 --------
 
 Choose a category that fits your issue.
 
-.. _typo3-version:
+
 
 .. index::
    single: Issue; TYPO3 version
+
+.. _typo3-version:
 
 TYPO3 version
 -------------
@@ -198,10 +207,12 @@ TYPO3 version
 
 Choose the TYPO3 version, where the error occurs.
 
-.. _php-version:
+
 
 .. index::
    single: Issue; PHP version
+
+.. _php-version:
 
 PHP Version
 -----------
@@ -211,10 +222,12 @@ PHP Version
 Choose the PHP version, where the error occurs. If in doubt, leave this blank.
 Usually, it is enough to supply the TYPO3 version.
 
-.. _create-issue-files:
+
 
 .. index::
    single: Issue; Files
+
+.. _create-issue-files:
 
 (optional) Files
 ----------------
@@ -241,6 +254,7 @@ Some hints for files:
 
    Use the "Preview" function at the bottom of the page to check if your
    issue is formatted well.
+
 
 .. _best-practices-bug-report:
 
@@ -307,10 +321,12 @@ the bug.
    example use headlines (h1, h2) to structure the parts, hightlighted code (<>) for
    code snippets, code for inline images (!image!).
 
-.. _formatting-in-redmine:
+
 
 .. index::
    single: Issue; Formatting
+
+.. _formatting-in-redmine:
 
 Hints for formatting in Redmine
 ===============================
@@ -323,10 +339,12 @@ merging patches. During the life cycle of a bug report and patch,
 several people will be reading your report. High readability and
 clarity makes things easier for everyone and saves time.
 
-.. _redmine-images:
+
 
 .. index::
    single: Issue; Images
+
+.. _redmine-images:
 
 Images
 ------

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -2,7 +2,7 @@
 
 .. highlight:: bash
 
-.. _Setting-up-your-Git-environment:
+
 
 .. index::
    single: Code Contribution Workflow; Git Setup
@@ -10,6 +10,7 @@
    single: Git; Setup
    single: Setup; Git
 
+.. _Setting-up-your-Git-environment:
 
 =========
 Git Setup
@@ -26,11 +27,13 @@ Prerequisites
 
       git clone git://git.typo3.org/Packages/TYPO3.CMS.git .
 
-.. _set-username-and-email:
+
 
 .. index::
    single: Code Contribution Workflow; git setup username and email
    single: Git Setup; username and email
+
+.. _set-username-and-email:
 
 Set Username and Email
 ======================
@@ -43,11 +46,13 @@ You need to instruct git to work with your name and email address. Make sure the
    git config user.name "Your Name"
    git config user.email "your-email@example.com"
 
-.. _set-autosetuprebase:
+
 
 .. index::
    single: Code Contribution Workflow; git setup rebase
    single: Git Setup; rebase
+
+.. _set-autosetuprebase:
 
 Set autosetuprebase
 ===================
@@ -60,13 +65,15 @@ to set the autosetuprebase option, such that your local commits are always rebas
    git config branch.autosetuprebase remote
 
 
-.. _setup-git-commit-hook:
-.. _git-setup-commit-msg-hook:
 
 .. index::
    single: Code Contribution Workflow; Git Hooks
    single: Git Setup; Git Hooks
    single: Setup; Git Hooks
+
+.. _setup-git-commit-hook:
+.. _git-setup-commit-msg-hook:
+
 
 Install Your Commit Hooks
 =========================
@@ -136,10 +143,12 @@ This will "install" the :file:`commit-msg` hook and :file:`pre-commit` hook.
 
 More information: :ref:`custom-composer-commands`.
 
-.. _git-setup-remote:
+
 
 .. index::
    single: Code Contribution Workflow; git setup remote
+
+.. _git-setup-remote:
 
 Setting up Your Remote
 ======================
@@ -150,11 +159,13 @@ You must instruct Git to push to Gerrit_ instead of the original repository. It 
 
    git config url."ssh://<YOUR_TYPO3_USERNAME>@review.typo3.org:29418".pushInsteadOf git://git.typo3.org
 
-.. _committemplate:
+
 
 .. index::
    single: Code Contribution Workflow; Commit Message Template
    single: Git Setup; Commit Message Template
+
+.. _committemplate:
 
 Setting up a Commit Message Template
 ====================================
@@ -182,6 +193,7 @@ Make Git use this file as a template for the commit message::
 
 For additional information about how to write a proper commit message
 see :ref:`commitmessage`.
+
 
 .. _git-show-config:
 

--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -20,10 +20,12 @@ If some of these are new for you, take a few minutes to read up about what they
 do for us. Maybe they prove useful in your everyday work as well.
 You can find installation tutorials in the :ref:`Appendix <appendix>` section.
 
-.. _prerequisites-composer:
+
 
 .. index::
    single: Tools; Composer
+
+.. _prerequisites-composer:
 
 Composer
 ========
@@ -59,10 +61,12 @@ Yarn and Grunt are not required for setting up a working TYPO3 installation. You
 will need them however if you plan to create patches which require changing frontend
 files. See :ref:`yarn build <yarn-build>` for more information on this.
 
-.. _prerequisites-yarn:
+
 
 .. index::
    single: Tools; Yarn
+
+.. _prerequisites-yarn:
 
 Yarn
 ----
@@ -106,10 +110,12 @@ Install all Required Packages
 The later section :ref:`yarn-build` will explain how to set
 everything up in your TYPO3 working directory.
 
-.. _prerequisites-grunt:
+
 
 .. index::
    single: Tools; Grunt
+
+.. _prerequisites-grunt:
 
 Grunt
 =====

--- a/Documentation/Setup/SetupIde.rst
+++ b/Documentation/Setup/SetupIde.rst
@@ -2,10 +2,12 @@
 
 .. highlight:: bash
 
-.. _setup-ide:
+
 
 .. index::
    single: Code Contribution Workflow; setup IDE
+
+.. _setup-ide:
 
 ==============
 Setup your IDE
@@ -14,10 +16,13 @@ Setup your IDE
 In the Appendix, you can find some hints that might be useful for
 :ref:`phpstorm-setup`.
 
-.. _coding-guidelines:
+
+
 
 .. index::
    single: Code Contribution Workflow; setup coding guidelines
+
+.. _coding-guidelines:
 
 Coding Guidelines
 -----------------

--- a/Documentation/Setup/SetupTypo3.rst
+++ b/Documentation/Setup/SetupTypo3.rst
@@ -8,11 +8,12 @@
 Setup the TYPO3 installation
 ============================
 
-.. _setup-typo3-git-clone:
-.. _git-clone:
 
 .. index::
    single: Code Contribution Workflow; git clone
+
+.. _setup-typo3-git-clone:
+.. _git-clone:
 
 git clone
 =========
@@ -20,6 +21,7 @@ git clone
 Switch into your **empty** htdocs directory of choice and clone a fresh master of TYPO3:: 
 
    git clone git://git.typo3.org/Packages/TYPO3.CMS.git .
+
 
 .. _git-guis:
 
@@ -34,10 +36,14 @@ here.
 * :ref:`Git Tower on OSX<gittower-osx>`
 * `GitKraken <https://www.gitkraken.com>`__
 
-.. _composer-install:
+
+
+
 
 .. index::
    single: Code Contribution Workflow; composer install
+
+.. _composer-install:
 
 composer install
 ================
@@ -60,10 +66,12 @@ This may take several minutes::
    # cd <cloned project>
    composer install
 
-.. _yarn-build:
+
 
 .. index::
    single: Code Contribution Workflow; yarn install
+
+.. _yarn-build:
 
 yarn install
 ============

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -1,11 +1,13 @@
 .. include:: ../Includes.txt
 .. highlight:: shell
 
-.. _testing:
+
 
 .. index::
    single: Code Contribution Workflow; Running Tests Locally
    single: Testing; Running Tests Locally
+
+.. _testing:
 
 =========
 Run Tests
@@ -48,11 +50,13 @@ in different environments (PHP version, database engine, ...). The script
 automatically runs docker using an image which corresponds to the environment
 you provide with the command line arguments.
 
-.. _run-tests-with-runtests.sh-using-docker:
+
 
 .. index::
    single: Code Contribution Workflow; Running Tests Locally using Docker
    single: Testing; Running Tests Locally using Docker
+
+.. _run-tests-with-runtests.sh-using-docker:
 
 Run Tests with runTests.sh using docker
 =======================================
@@ -187,11 +191,13 @@ standard exit codes:
 Reports of the acceptance tests will be stored in
 :file:`typo3temp/var/tests/AcceptanceReports` with screenshots from the browser.
 
-.. _run-tests-directly-without-docker:
+
 
 .. index::
    single: Code Contribution Workflow; Running Tests Locally without Docker
    single: Testing; Running Tests Locally without Docker
+
+.. _run-tests-directly-without-docker:
 
 Run tests directly without docker
 =================================
@@ -241,12 +247,13 @@ Run all functional tests
 
   bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml
 
-.. _check-for-coding-guidelines:
+
 
 .. index::
    single: Code Contribution Workflow; Checking for Coding Guidelines
    single: Tools; Checking for Coding Guidelines
 
+.. _check-for-coding-guidelines:
 
 Check for Coding Guidelines
 ---------------------------

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -1,23 +1,23 @@
 .. include:: ../Includes.txt
 .. highlight:: shell
 
-.. _troubleshooting:
+
 
 .. index::
    single: Troubleshooting
+
+.. _troubleshooting:
 
 ===============
 Troubleshooting
 ===============
 
-.. Some of this text was taken from the Wiki page: https://wiki.typo3.org/TroubleShooting_(Git)
-
-.. _git-troubleshooting:
 
 .. index::
    single: Git; Troubleshooting
    single: Troubleshooting; Git
 
+.. _git-troubleshooting:
 
 Git Troubleshooting
 ===================

--- a/Documentation/WorkflowExplained/Index.rst
+++ b/Documentation/WorkflowExplained/Index.rst
@@ -1,9 +1,11 @@
 .. include:: ../Includes.txt
 
-.. _workflow-explained:
+
 
 .. index::
    single: Contribution Workflow; Core Explained
+
+.. _workflow-explained:
 
 ============================
 TYPO3 Contribution Explained


### PR DESCRIPTION
When using the index directives, they must be BEFORE the label for
headers. Otherwise the anchortext in references (:ref:) will not
be displayed correctly.