### PR TITLE
Add information about pushing to refs/for/master again

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -193,8 +193,12 @@ Step by Step Walkthrough
 
    To submit the patch to Gerrit, issue the following command::
 
-      git push
+      git push origin HEAD:refs/for/master
 
+   If you have setup the default as described in :ref:`git-setup-remote`
+   it is sufficient to use::
+
+      git push
 
    In case you want to push a "Work in progress", check out:
    :ref:`git-work-in-progress`.
@@ -217,7 +221,6 @@ Step by Step Walkthrough
    If the automatically starting pre-merge build fails due to an error on Bamboo which
    isn't caused by your patch (e.g. time out) you can restart it on
    `Intercept <https://intercept.typo3.com/admin/bamboo/core>`__.
-   
 
    Advanced users / core team only: See
    :ref:`cheat sheet: other branches <cheat-sheet-git-other-branches>`


### PR DESCRIPTION
We add the full push command again for pushing to master:
git push origin HEAD:refs/for/master

This was simplified in previous PR as the full command is
not necessary if already configured.

However, this change was made too abrupt and does not give
people the time to update their configuration and adjust
their workflow.

So we added the (previous) command again with a hint and a
link to the configuration section.

Pushing to master was done like this:

  git push origin HEAD:refs/for/master

This can be simplified by:

  git push

if already configured like this:
  git config remote.origin.push +refs/heads/master:refs/for/master

Related: #167