### PR TITLE
Fix invalid links to Forger

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -246,7 +246,7 @@ Helpful links
 
 * `Gerrit <https://review.typo3.org>`__ Review server
 * `Forge <https://forge.typo3.org>`__ Issue tracker
-* `Forger <https://forger.typo3.org>`__ Search for reviews and issues
+* `Forger <https://forger.typo3.com>`__ Search for reviews and issues
 * `Slack <https://slack.typo3.org>`__ chat system
 
 Next Steps

--- a/Documentation/Forger/Index.rst
+++ b/Documentation/Forger/Index.rst
@@ -15,7 +15,7 @@ Introduction to Forger
    .. image:: _assets/dave.png
       :width: 200px
 
-   https://forger.typo3.org
+   https://forger.typo3.com/
 
 The majority of the work in the TYPO3 project is managed via a tool called Forger_, which acts as a read-only view on issues
 and reviews.
@@ -26,7 +26,7 @@ Forger_ performs several tasks, including:
    found on the start page and in the top right corner.
 
 #. Visualize the current development with a lot of useful **graphs**. You can learn more about the graphs
-   `here <https://forger.typo3.org/help>`_.
+   `here <https://forger.typo3.com/help>`_.
 
 #. Show and filter **reviews** incl. filters to easily find things to review. Check out the ``Reviews`` menu.
 

--- a/Documentation/HandlingAPatch/FindAReview.rst
+++ b/Documentation/HandlingAPatch/FindAReview.rst
@@ -21,7 +21,7 @@ is most convenient for you or what fits your needs.
 Forger
 ======
 
-In any case, you can use `Forger <https://forger.typo3.org>`__ to
+In any case, you can use `Forger <https://forger.typo3.com>`__ to
 search for the review.
 
 Examples:

--- a/Documentation/HandlingAPatch/GerritBasics.rst
+++ b/Documentation/HandlingAPatch/GerritBasics.rst
@@ -43,7 +43,7 @@ This is a screenshot of an open review on Gerrit_. We will go through the parts 
 
 #. The **search box** lets you write complex search queries with little coding knowledge. For detailed information on how to
    use the search, refer to the official documentation on https://review.typo3.org/Documentation/user-search.html.
-   Most people use `Forger <https://forger.typo3.org>`__, because it provides more sophisticated ways to
+   Most people use `Forger <https://forger.typo3.com>`__, because it provides more sophisticated ways to
    find a review. Look at :ref:`Find-a-review` for more information.
 
 #. The **commit message** formatted like we explained in :ref:`"The commit message"<commitmessage>`.
@@ -58,7 +58,7 @@ This is a screenshot of an open review on Gerrit_. We will go through the parts 
 
 #. The **current review status**. Here you can see who has voted (and how they voted) on a change. The votes only apply
    to one given patchset. If a new patchset is uploaded, it must be revoted. Note the +1 by TYPO3com, which means that
-   the automatic testsuite ran successfully. 
+   the automatic testsuite ran successfully.
 
 #. All **changed files** in this current change. You can click every file to take a look at what exactly has changed. There
    is a select box on top of the file list that allows you to do a diff between patch sets to quickly see what has changed.

--- a/Documentation/Includes.txt
+++ b/Documentation/Includes.txt
@@ -19,4 +19,4 @@
 .. _Gerrit: https://review.typo3.org
 .. _T3O: https://typo3.org
 .. _Slack: https://slack.typo3.org
-.. _Forger: https://forger.typo3.org
+.. _Forger: https://forger.typo3.com


### PR DESCRIPTION
It must be forger.typo3.COM, not forger.typo3.ORG