### PR TITLE
Add "PHPUnit Enhancement" to PhpStorm plugins

### DIFF
--- a/Documentation/Appendix/IdePhpStormSetup.rst
+++ b/Documentation/Appendix/IdePhpStormSetup.rst
@@ -125,6 +125,9 @@ Recommended Plugins
   This will show you errors in your reStructuredText files (file ending .rst)
   when you are editing the core changelog or are updating the documentation
   for a system extension.
+* `PHPUnit Enhancement <https://plugins.jetbrains.com/plugin/9674-phpunit-enhancement>`__
+  This helps with code-completion and navigation in combination with unit tests
+  and Prophecy (among other things).
 
 Optional Plugins
 ----------------


### PR DESCRIPTION
Especially when working with Prophecy (and TYPO3 tests are full of
it), working with PhpStorm without this plugin (or other similar
plugins) can be quite a hassle.