### PR TITLE
[TASK] Replace `git@github.com:` by `git://github.com/`

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -232,7 +232,7 @@ Or, compare the :file:`.git/config` file inside the repository::
        bare = false
        logallrefupdates = true
     [remote "origin"]
-        url = git@github.com:typo3/typo3
+        url = git://github.com/typo3/typo3
         fetch = +refs/heads/*:refs/remotes/origin/*
         pushurl = ssh://<TYPO3_USER_NAME>@review.typo3.org:29418/Packages/TYPO3.CMS.git
     [branch "master"]


### PR DESCRIPTION
See https://github.com/TYPO3-Documentation/T3DocTeam/issues/162 for details.