### PR TITLE
Update SettingUpTypo3Ddev.rst

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -53,17 +53,6 @@ instructions.
    Composer and yarn can run inside of DDEV, so there is no need to set them up locally.
 
 
-Clone TYPO3
-===========
-
-Create a clone of the TYPO3 git repository as described in :ref:`git-clone`::
-
-   mkdir t3master
-   cd t3master
-   git clone git@github.com:typo3/typo3 .
-
-
-
 Configure DDEV
 ==============
 


### PR DESCRIPTION
remove the "Clone TYPO3" Section from docs since you dont need to clone the typo3 repo if you use ddev .