### PR TITLE
[TASK] Update core setup with header

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -18,7 +18,7 @@
 
 
 =======================================
-TYPO3 core contribution setup with DDEV
+TYPO3 Core contribution setup with DDEV
 =======================================
 
 `DDEV <https://ddev.readthedocs.io>`__ provides several pre-configured

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -17,9 +17,9 @@
    to install TYPO3 using Composer for a project.
 
 
-==========================
-Setting up TYPO3 with DDEV
-==========================
+=======================================
+TYPO3 core contribution setup with DDEV
+=======================================
 
 `DDEV <https://ddev.readthedocs.io>`__ provides several pre-configured
 environments based on Docker.


### PR DESCRIPTION
After adding the warning on the top there are still people using this guide to setup their TYPO3 instance with DDEV.