### PR TITLE
Add information about changed repository

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -16,6 +16,19 @@
 Git Setup
 =========
 
+.. note::
+
+   If you are working on a previously cloned, older repository, the TYPO3
+   repository URL changed to GitHub. Existing repositories can be adapted
+   like this:
+   
+   .. code-block:: bash
+   
+      $ git remote set-url origin git://github.com/typo3/typo3
+      $ git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
+      
+   See `Renaming the TYPO3 GitHub Repository <https://typo3.org/article/renaming-the-typo3-github-repository>`__.   
+
 These steps will walk you through your basic Git setup when working with TYPO3.
 
 Prerequisites


### PR DESCRIPTION
Because the repository moved to GitHub and occasionally
people are looking for information about how to change
*existing* local repos and reporting problems on Slack.