### PR TITLE
Avoid using unauthenticated Git protocol on GitHub

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -39,7 +39,7 @@ Git Setup
    .. code-block:: bash
 
        # set remote url for "origin"
-       git remote set-url origin git://github.com/typo3/typo3
+       git remote set-url origin https://github.com/typo3/typo3.git
        # set push URL to gerrit (this has not changed)
        git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
 


### PR DESCRIPTION
see https://github.blog/2021-09-01-improving-git-protocol-security-github/
> January 11, 2022: Final brownout. [...]