### PR TITLE
[TASK] Remove outdated links to the TYPO3 wiki

### DIFF
--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -71,9 +71,8 @@ Possible keywords are:
    feature, but it could also be removed. Features may exclusively be targeted for
    the "main" branch of TYPO3 CMS, because no new features are allowed in older
    branches. Exceptions to this have to be discussed on a case-to-case basis with
-   the designated release managers. Features have to be documented according to
-   `TYPO3 CMS Important Changes Documentation HowTo
-   <https://wiki.typo3.org/TYPO3_CMS_Important_Changes_Documentation_HowTo>`_ .
+   the designated release managers. Features have to be documented in the
+   See :ref:`changelog <changelog>`.
 
 `[DOCS]`
    This tag is used for changes regarding the documentation.
@@ -87,8 +86,7 @@ Additionally other flags  **should be added** under certain circumstances:
    Breaking change. After this patch, something works different than before
    and the user / admin / extension developer will have to change something. Has to
    be  **documented** accordingly and should only be targeted for the main branch.
-   See `TYPO3 CMS Important Changes Documentation HowTo
-   <https://wiki.typo3.org/TYPO3_CMS_Important_Changes_Documentation_HowTo>`_.
+   See :ref:`Editing the changelog <changelog>`.
 
 .. important::
 

--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -72,7 +72,7 @@ Possible keywords are:
    the "main" branch of TYPO3 CMS, because no new features are allowed in older
    branches. Exceptions to this have to be discussed on a case-to-case basis with
    the designated release managers. Features have to be documented in the
-   See :ref:`changelog <changelog>`.
+   :ref:`changelog <changelog>`.
 
 `[DOCS]`
    This tag is used for changes regarding the documentation.

--- a/Documentation/Appendix/Slack.rst
+++ b/Documentation/Appendix/Slack.rst
@@ -43,8 +43,7 @@ or the short form: **be nice, be helpful!**
 Botty on Slack
 ~~~~~~~~~~~~~~
 
-Also checkout the help page on `"Botty" <https://wiki.typo3.org/T3Bot>`__, the TYPO3 slack bot. We will show you
-some of its commands later in this manual.
+Also the TYPO3 slack bot. We will show you some of its commands later in this manual.
 
 You cannot use Botty in your private channel or in a direct messaging channel with someone else. Botty will
 only be available in a public channel, to which it has been invited (which is the case in #typo3-cms-coredev).


### PR DESCRIPTION
refs https://github.com/TYPO3-Documentation/T3DocTeam/issues/170

releases: main