### PR TITLE
[DOCS] Add necessary packages for yarn build process

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -91,6 +91,9 @@ Set correct PHP version, for example::
 
    php_version: "8.1"
 
+Add necessary packages for the :ref:`yarn build process <Yarn build process>`:
+
+   webimage_extra_packages: [automake,build-essential]
 
 Start DDEV
 ==========
@@ -118,6 +121,8 @@ This runs inside the container and thus uses your configured Composer version::
 
    ddev composer install
 
+Yarn build process
+==================
 
 It is not necessary for the initial build, but once you change some assets (e.g.
 Typescript, SCSS files), you should build with yarn. You might like to try this

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -91,7 +91,7 @@ Set correct PHP version, for example::
 
    php_version: "8.1"
 
-Add necessary packages for the :ref:`yarn build process <Yarn build process>`:
+Add necessary packages for the :ref:`yarn build process <Yarn build process>` (only needed if you are working on assets):
 
    webimage_extra_packages: [automake,build-essential]
 


### PR DESCRIPTION
To run command 'ddev exec "cd Build && yarn install"' successfully you need to add packages 'automake' and 'build-essential' (or at least 'make' and 'g++' instead of 'build-essential') in .ddev/config.yaml. Otherwise you will get '/bin/sh: 1: autoreconf: not found' when running 'gifsicle' and 'Error: not found: make' when running 'node-sass'.