### PR TITLE
Remove video from DDEV page

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -33,11 +33,6 @@ or Database running on your machine, make sure there are no conflicts.
 You can change the default ports DDEV uses (e.g. port 80 / 443 for Webserver)
 in :file:`.ddev/config.yaml` before you start it.
 
-You can watch a video tutorial about setting up TYPO3 with DDEV, or go through the steps outlined below.
-
-.. youtube:: HZVMPoI9SIk
-
-
 Prerequisites
 =============
 


### PR DESCRIPTION
The video explains setting up a TYPO3 site with DDEV, but
not for core development. This means, it is slightly different,
e.g. TYPO3 is intalled via Composer and not based on a cloned
git repository of TYPO3.

In the docs, currently, it is recommended to watch the video
OR follow the steps below. This is misleading, as following
the video will not get you a TYPO3 site ready to be used for
core development.

While the video provides some more in-depth information, this
is not that much relevant for setting up TYPO3 for core development.

Most likely, in the future, there will be further changes for setting
up DDEV (e.g. use runTest.sh) and the page will continuously be
updated, but the video will not.