### PR TITLE
Update Setup > Prerequisites

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -53,8 +53,8 @@ On these pages you will learn how to become a TYPO3 Core contributor.
 
    Account/Index
    Setup/Prerequisites
-   Setup/SetupTypo3
    Setup/Git/Index
+   Setup/SetupTypo3
    Setup/UseStyleguide
    Setup/SetupIde
 

--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -8,7 +8,7 @@
 Prerequisites and Useful Tools
 ==============================
 
-Necessary:
+Required:
 
 *  Git
 *  Docker and Docker Composer for running :file:`runTests.sh` to setup, build,
@@ -21,8 +21,8 @@ Recommended:
    can also use a simple editor, a properly setup IDE will help with
    code-completion, marking errors and applying coding guidelines.
 *  DDEV for setting up the TYPO3 installation. Alternative methods
-   are possible, e.g. using a locally installed Webserver and database. DDEV
+   are possible, e.g. using a locally installed web server and database. DDEV
    provides custom configurations for TYPO3 which can be used for core
    development as well.
 
-Using these tools will be described in depth, further along in this chapter.
+Information on using these tools is covered in detail later on this chapter.

--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -8,133 +8,21 @@
 Prerequisites and Useful Tools
 ==============================
 
-.. note::
+Necessary:
 
-   If you are using DDEV to setup your TYPO3 installation, it is not necessary to install
-   the tools locally (e.g. Composer, yarn). They will be supplied by DDEV and you can run
-   them inside the container.
+*  Git
+*  Docker and Docker Composer for running :file:`runTests.sh` to setup, build,
+   perform checks and run tests. Alternatively, you can run some of the tools
+   locally or within DDEV. In that case, they must also be installed.
 
-   In that case you can skip right to :ref:`DDEV <settting-up-typo3-with-ddev>`.
+Recommended:
 
-Here's a list of the tools we use in the TYPO3 project:
+*  IDE with TYPO3 plugins, such as PhpStorm or Visual Studio Code. While you
+   can also use a simple editor, a properly setup IDE will help with
+   code-completion, marking errors and applying coding guidelines.
+*  DDEV for setting up the TYPO3 installation. Alternative methods
+   are possible, e.g. using a locally installed Webserver and database. DDEV
+   provides custom configurations for TYPO3 which can be used for core
+   development as well.
 
-
-* :ref:`Composer <prerequisites-composer>`
-* :ref:`Yarn <prerequisites-yarn>`
-* :ref:`Grunt <prerequisites-grunt>`
-
-
-If some of these are new for you, take a few minutes to read up about what they
-do for us. Maybe they prove useful in your everyday work as well.
-You can find installation tutorials in the :ref:`Appendix <appendix>` section.
-
-
-
-.. index::
-   single: Tools; Composer
-
-.. _prerequisites-composer:
-
-Composer
-========
-
-*-- required (depends)*
-
-If you use a container solution, such as DDEV, you can run composer install from inside
-the container, see :ref:`composer-install`.
-
-
-.. sidebar:: Composer
-
-   You can learn a lot more about composer on their website https://getcomposer.org/.
-   Also, look at :ref:`composer` in the Appendix for some
-   information specific to the TYPO3 core contribution toolchain.
-
-Composer is a dependency manager for PHP.
-
-Follow the
-installation instructions from https://getcomposer.org. Afterwards, you should
-have a working executable `composer` available.
-
-Verify composer is working::
-
-   $ composer --version
-
-Setting up Your Frontend Build Toolchain.
-=========================================
-
-*-- required (depends)*
-
-Yarn and Grunt are not required for setting up a working TYPO3 installation. You
-will need them however if you plan to create patches which require changing frontend
-files. See :ref:`yarn build <yarn-build>` for more information on this.
-
-
-
-.. index::
-   single: Tools; Yarn
-
-.. _prerequisites-yarn:
-
-Yarn
-----
-
-TYPO3 itself does not need yarn to run, but yarn is something similar to composer, but for the world outside of PHP.
-We will be mainly using yarn to get helpful tools like Grunt and Bower.
-
-Install on MacOS
-~~~~~~~~~~~~~~~~
-
-1. install the packagemanager homebrew::
-
-      /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-2. install yarn::
-
-      brew install yarn
-
-
-Installer for Windows and MacOS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Go to https://yarnpkg.com/lang/en/docs/install/#windows-tab
-
-2. Download the package and install
-
-
-Linux
-~~~~~
-
-1. Go to https://yarnpkg.com/lang/en/docs/install/#linux-tab
-
-2. Download the package and install
-
-For additional infos see https://yarnpkg.com
-
-
-Install all Required Packages
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The later section :ref:`yarn-build` will explain how to set
-everything up in your TYPO3 working directory.
-
-
-
-.. index::
-   single: Tools; Grunt
-
-.. _prerequisites-grunt:
-
-Grunt
-=====
-
-.. sidebar:: Grunt
-
-   You can learn more about Grunt on their website http://gruntjs.com/.
-
-Grunt is a JavaScript-based task runner. While this does not sound very expressive at first this is basically, what grunt
-does - it runs tasks for us.
-
-In our case grunt compiles CSS, minifies and concatenates JavaScript files, runs syntax checks and a couple of
-other useful things. The good news is that TYPO3 comes with a predefined set of tasks that grunt will run, so you don't
-have to take care of all the busywork underneath.
+Using these tools will be described in depth, further along in this chapter.


### PR DESCRIPTION
To streamline the contribution guide, some sections for installing
and executing the tools are removed or changed.

Specifically, the listed tool installation on the prerequisites
page can be found elsewhere (and will usually be more up-to-date
elsewhere).

Explanation:

Previously, the setup and tool installation existed in various
places, sometimes with differening instructions. For example,
the Prerequisites page included instructions for installing
yarn on Mac OSX, but there was also a page in the appendix with
different instructions. Additionally, the installation instructions
for the platforms are  easy to find elsewhere and are more up-to-date
on the documentation pages of these tools.

On top of this, dependency on tool installation is no longer a
prerequisite if runTests.sh is used (or even if DDEV is used without
runTests.sh).

Related: #253
Related: #249