### PR TITLE
Change order in setup for Git setup

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -38,13 +38,13 @@ You can watch a video tutorial about setting up TYPO3 with DDEV, or go through t
 .. youtube:: HZVMPoI9SIk
 
 
-Setting up the prerequisites
-============================
+Prerequisites
+=============
 
-You will need to install Docker and other
+*  Install Docker and other
 `ddev system requirements <https://ddev.readthedocs.io/en/latest/#system-requirements>`__.
 
-Then install DDEV as described in the
+*  Install DDEV as described in the
 `Installation <https://ddev.readthedocs.io/en/latest/#installation>`__
 instructions.
 
@@ -52,16 +52,8 @@ instructions.
 
    Composer and yarn can run inside of DDEV, so there is no need to set them up locally.
 
-
-Clone TYPO3
-===========
-
-Create a clone of the TYPO3 git repository as described in :ref:`git-clone`::
-
-   mkdir t3coredev
-   cd t3coredev
-   git clone git@github.com:typo3/typo3 .
-
+*  You have cloned the TYPO3 git repository as described in :ref:`git-clone` and
+   have switched to the directory which contains the local Git repository.
 
 
 Configure DDEV
@@ -191,7 +183,7 @@ If you are in the middle of setting up a TYPO3 installation for core development
 
 .. rst-class:: horizbuttons-primary-m
 
-- :ref:`Setting-up-your-Git-environment`.
+- :ref:`after-setup-typo3`.
 
 
 Resources

--- a/Documentation/Appendix/SettingUpTypo3Manually.rst
+++ b/Documentation/Appendix/SettingUpTypo3Manually.rst
@@ -20,20 +20,8 @@ You will need to set up the prerequisites for your operating system. Look at the
 
 * :ref:`setting-up-typo3-manually-linux`
 
-
-Clone TYPO3
-===========
-
-Create a clone of git as described in :ref:`git-clone`, run :ref:`composer-install` and
-optionally :ref:`yarn-build`.
-
-
-::
-
-   git clone git@github.com:typo3/typo3 .
-   composer install
-
-
+You have cloned the TYPO3 git repository as described in :ref:`git-clone` and
+have switched to the directory which contains the local Git repository.
 
 Create the database
 ===================

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -53,8 +53,8 @@ On these pages you will learn how to become a TYPO3 Core contributor.
 
    Account/Index
    Setup/Prerequisites
-   Setup/SetupTypo3
    Setup/Git/Index
+   Setup/SetupTypo3
    Setup/UseStyleguide
    Setup/SetupIde
 

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -52,14 +52,24 @@ Git Setup
 
 These steps will walk you through your basic Git setup when working with TYPO3.
 
-Prerequisites
-=============
+.. index::
+   single: Code Contribution Workflow; git clone
+   single: git; git clone
 
-* If you want to get an introduction to how our workflow works, :ref:`head over here<workflow-explained>`
-* We expect you have a fully-fledged web development setup at hand. If you are not sure, though, :ref:`take a look here <prerequisites>`.
-* Make sure, you have cloned the TYPO3 source as described previously in :ref:`setup-typo3-git-clone`::
+.. _setup-typo3-git-clone:
+.. _git-clone:
 
-      git clone git@github.com:typo3/typo3 .
+git clone
+=========
+
+Create a directory for your TYPO3 core installation and change into it, e.g.::
+
+   mkdir /var/www/t3coredev
+   cd /var/www/t3coredev
+
+Clone the TYPO3 CMS core repository::
+
+   git clone git@github.com:typo3/typo3 .
 
 
 

--- a/Documentation/Setup/SetupTypo3.rst
+++ b/Documentation/Setup/SetupTypo3.rst
@@ -17,36 +17,6 @@ Setup the TYPO3 installation
 
    - :ref:`DDEV <settting-up-typo3-with-ddev>`
 
-.. index::
-   single: Code Contribution Workflow; git clone
-
-.. _setup-typo3-git-clone:
-.. _git-clone:
-
-git clone
-=========
-
-Switch into your **empty** htdocs directory of choice and clone the TYPO3 CMS core repository::
-
-   git clone git@github.com:typo3/typo3 .
-
-
-.. _git-guis:
-
-Git GUIs
-========
-
-If you rather like to work with your favorite Git GUI, we compiled a list of the ones used throughout the core team
-here.
-
-* :ref:`SourceTree on Windows<windows-clonewithsourcetree>`
-* SourceTree on OSX
-* :ref:`Git Tower on OSX<gittower-osx>`
-* `GitKraken <https://www.gitkraken.com>`__
-
-
-
-
 
 .. index::
    single: Code Contribution Workflow; composer install

--- a/Documentation/Setup/UseStyleguide.rst
+++ b/Documentation/Setup/UseStyleguide.rst
@@ -3,6 +3,7 @@
 .. highlight:: bash
 
 .. _use-styleguide:
+.. _after-setup-typo3:
 
 ==================
 Use EXT:styleguide


### PR DESCRIPTION
The Git setup page is moved further to the top. This way, the
number of times "git clone" is explained can be reduced. Git clone is explained
on the Git page and the subsequent pages do not need to repeat this.