### PR TITLE
[On hold] Remove note for branch rename (do not merge yet)

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -16,40 +16,6 @@
 Git Setup
 =========
 
-.. note::
-
-   If you are working on a previously cloned, older repository, the TYPO3
-   repository URL changed to GitHub **and the branch "master" changed to "main".**
-   Existing repositories can be adapted like this:
-
-   To switch from master to main:
-
-   .. code-block:: bash
-
-       # Make sure that git pull loads from the "main" branch
-       git branch --set-upstream-to origin/main
-
-       # Rename your current "master" branch locally to "main" to match TYPO3's naming scheme
-       git branch -m master main
-
-   Please also adapt your :ref:`commit message template <committemplate>`, if configured.
-
-   If not using the GitHub remote yet, also change:
-
-   .. code-block:: bash
-
-       # set remote url for "origin"
-       git remote set-url origin https://github.com/typo3/typo3.git
-       # set push URL to gerrit (this has not changed)
-       git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
-
-
-   See
-
-   * `TYPO3 Core Development to Change Branch Name <https://typo3.org/article/typo3-core-development-to-change-branch-name>`__ (November 28, 2021)
-   * `Renaming the TYPO3 GitHub Repository <https://typo3.org/article/renaming-the-typo3-github-repository>`__. (July 6, 2021)
-
-
 These steps will walk you through your basic Git setup when working with TYPO3.
 
 Prerequisites


### PR DESCRIPTION
Remove notes about branch renaming from master to main and moving
to GitHub. These steps are only necessary if someone is using an
already cloned Git repository.

The master / main switch was done at the end of November, 2021, so
there should have been ample time to adapt.

The note bloats up the page and may additionally confuse newcomers.