### PR TITLE
Reflect other responsibilities of runTests.sh

### DIFF
--- a/Documentation/Setup/Prerequisites.rst
+++ b/Documentation/Setup/Prerequisites.rst
@@ -11,9 +11,9 @@ Prerequisites and Useful Tools
 Required:
 
 *  Git
-*  Docker and Docker Composer for running :file:`runTests.sh` to setup, build,
-   perform checks and run tests. Alternatively, you can run some of the tools
-   locally or within DDEV. In that case, they must also be installed.
+*  Once you have setup the Git repository, it is advised to look at the listed
+   dependencies for  :file:`runTests.sh` by running
+   :bash:`Build/Scripts/runTests.sh -h` (see :ref:`runTests_sh`).
 
 Recommended:
 


### PR DESCRIPTION
This change converts the page "Run tests" to be about runTests.sh
in general - including running the tests but not restricted to this.

The page "Run tests" used to be just about running test. However,
more and more commands for checking, fixing, building etc. have
since been added to the script runTests.sh.