### PR TITLE
Remove an uncessary note

### DIFF
--- a/Documentation/Setup/SetupTypo3.rst
+++ b/Documentation/Setup/SetupTypo3.rst
@@ -56,8 +56,7 @@ here.
 composer install
 ================
 
-*-- required* (unless run `composer install` from container solution, such as DDEV,
-see :ref:`composer-install`)
+*-- required*
 
 .. tip::
 


### PR DESCRIPTION
This note is uncessary because:

- the reference points to the same section we are currently in
- pointing out differences for DDEV are no longer necessary and
  also we already directed reasers to the DDEV setup instructions
  on the top of the page.