### PR TITLE
Add commands with runTests.sh for building

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -74,18 +74,23 @@ Edit configuration
 
 Edit the configuration file :file:`.ddev/config.yaml`.
 
-Set correct PHP version, for example::
+Set correct PHP version, for example
+
+.. code-block:: yaml
 
    php_version: "8.1"
 
-Add necessary packages for the :ref:`yarn build process <Yarn build process>` (only needed if you are working on assets):
+Add necessary packages for the :ref:`yarn build process <Yarn build process>`
+(only needed if you are working on assets):
+
+.. code-block:: yaml
 
    webimage_extra_packages: [automake,build-essential]
 
 Start DDEV
 ==========
 
-::
+.. code-block:: bash
 
    ddev start
 
@@ -120,12 +125,12 @@ using the instructions in :ref:`run-tests-directly-without-docker`.
 
    .. group-tab:: DDEV
 
-      ::
+      .. code-block:: bash
 
          ddev composer install
 
 
-The following is not necessary for the initial build, but once you change some assets (e.g.
+The following is not necessary for the initial build, but once you change some assets (for example
 Typescript, SCSS files), you must build them. You might like to try this
 now:
 
@@ -133,14 +138,14 @@ now:
 
    .. group-tab:: runTests.sh
 
-      ::
+      .. code-block:: bash
 
          Build/Scripts/runTests.sh -s buildCss
          Build/Scripts/runTests.sh -s buildJavascript
 
    .. group-tab:: DDEV
 
-      ::
+      .. code-block:: bash
 
          ddev exec "cd Build && yarn install"
          ddev exec "cd Build && yarn build"
@@ -157,7 +162,9 @@ now:
 DDEV describe
 =============
 
-Let DDEV dump information::
+Let DDEV dump information:
+
+.. code-block:: bash
 
    ddev describe
 
@@ -166,7 +173,9 @@ Displays information about the project, its URLs and access to phpMyAdmin, MailH
 FIRST_INSTALL
 =============
 
-Create a file `FIRST_INSTALL`::
+Create a file `FIRST_INSTALL`:
+
+.. code-block:: bash
 
    touch FIRST_INSTALL
 

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -107,7 +107,7 @@ Build
 It is recommended to run tasks such as :bash:`composer install` etc. via the
 :ref:`runTests.sh <runTests_sh>` script. We provide the direct commands in some
 places - in case there is good reason to run the commands directly. But, if you
-need the direct commands, you are encouraged to check look them up yourself
+need the direct commands, you are encouraged to look them up
 using the instructions in :ref:`run-tests-directly-without-docker`.
 
 .. tabs::

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -101,25 +101,53 @@ care of that below.
 
 .. _ddev-composer-install:
 
-Install dependencies via composer
-=================================
+Build
+=====
 
-This runs inside the container and thus uses your configured Composer version::
+It is recommended to run tasks such as :bash:`composer install` etc. via the
+:ref:`runTests.sh <runTests_sh>` script. We provide the direct commands in some
+places - in case there is good reason to run the commands directly. But, if you
+need the direct commands, you are encouraged to check look them up yourself
+using the instructions in :ref:`run-tests-directly-without-docker`.
 
-   ddev composer install
+.. tabs::
 
-Yarn build process
-==================
+   .. group-tab:: runTests.sh
 
-It is not necessary for the initial build, but once you change some assets (e.g.
-Typescript, SCSS files), you should build with yarn. You might like to try this
-now::
+      .. code-block:: bash
 
-   ddev exec "cd Build && yarn install"
-   ddev exec "cd Build && yarn build"
+         Build/Scripts/runTests.sh -s composerInstall
 
-The first command is required once, the second (build) command is required after
-every change of a resource file.
+   .. group-tab:: DDEV
+
+      ::
+
+         ddev composer install
+
+
+The following is not necessary for the initial build, but once you change some assets (e.g.
+Typescript, SCSS files), you must build them. You might like to try this
+now:
+
+.. tabs::
+
+   .. group-tab:: runTests.sh
+
+      ::
+
+         Build/Scripts/runTests.sh -s buildCss
+         Build/Scripts/runTests.sh -s buildJavascript
+
+   .. group-tab:: DDEV
+
+      ::
+
+         ddev exec "cd Build && yarn install"
+         ddev exec "cd Build && yarn build"
+
+
+      The first command is required once, the second (build) command is required after
+      every change of a resource file.
 
 .. seealso::
 

--- a/Documentation/Setup/SetupTypo3.rst
+++ b/Documentation/Setup/SetupTypo3.rst
@@ -3,11 +3,11 @@
 .. highlight:: bash
 
 .. _setup-typo3:
+.. _setup-typo3-installation:
 
 ============================
 Setup the TYPO3 installation
 ============================
-
 
 .. important::
 
@@ -17,6 +17,14 @@ Setup the TYPO3 installation
 
    - :ref:`DDEV <settting-up-typo3-with-ddev>`
 
+You will now need to setup a working installation
+of TYPO3. There are different ways how you can do this. We
+provide a few examples in the Appendix:
+
+* :ref:`DDEV <settting-up-typo3-with-ddev>`
+* :ref:`setting-up-typo3-manually`
+
+In any case, use the cloned Git repository as basis (see :ref:`git-clone`).
 
 .. index::
    single: Code Contribution Workflow; composer install
@@ -26,22 +34,11 @@ Setup the TYPO3 installation
 composer install
 ================
 
-*-- required*
+Run composer install in the same directory you cloned the TYPO3 CMS core
+repository.
 
-.. tip::
-
-   If you plan to use a Docker based container solution for setting up your
-   TYPO3 installation (for example using :ref:`DDEV <settting-up-typo3-with-ddev>`),
-   you can perform the step `composer install` later and let it run
-   :ref:`inside your Docker container <ddev-composer-install>`.
-
-Information about :ref:`setting up Composer <prerequisites-composer>` is found in previous chapter.
-
-Run composer install in the same directory you cloned the TYPO3 CMS core repository to.
-This may take several minutes::
-
-   # cd <cloned project>
-   composer install
+It is recommended to use runTests.sh for this. The "direct command" is an
+alternative. You only need to run one of these!
 
 
 .. note::
@@ -53,66 +50,24 @@ This may take several minutes::
    `composer install` may need to export the `COMPOSER_ROOT_VERSION environment variable <https://getcomposer.org/doc/03-cli.md#composer-root-version>`__.
    Here you need to set a full version string matching the TYPO3 version of your clone.
 
-   Example::
+   Example:
+
+   .. code-block:: bash
 
       # cd <cloned project>
       export COMPOSER_ROOT_VERSION=12.0.0
 
 
+.. tabs::
 
+   .. group-tab:: runTests.sh
 
-.. index::
-   single: Code Contribution Workflow; yarn install
+      .. code-block:: bash
 
-.. _yarn-build:
+         Build/Scripts/runTests.sh -s composerInstall
 
-yarn install
-============
+   .. group-tab:: direct command
 
-.. tip::
+      .. code-block:: bash
 
-   This step is not necessary to setup a working environment. You may however
-   want to test this step because you might be needing it later if you make
-   changes in the frontend SCSS or TypeScript files in :file:`Build/Sources`.
-   If not, skip to :ref:`setup-typo3-installation`.
-
-Go to the `Build` folder of your TYPO3 install root directory.
-Install all dependencies with `yarn install`.
-Wait for the the end of the install progress.
-Type `yarn build` for the build process.
-
-::
-
-   cd Build
-   yarn install
-   yarn build
-   cd ..
-
-
-.. _yarn-tasks:
-
-yarn tasks
-----------
-
-The following is a list of available build targets (see package.json for an
-up-to-date list). You will only be needing these if you want to do something
-specific. Usually, it should suffice to use `yarn install` and `yarn build`.
-
--   `yarn build` - Compile everything.
--   `yarn build-css` - Compile SCSS to CSS.
--   `yarn lint` -  Test your SCSS and ts files.
--   `yarn build-js` - Compile JavaScript.
--   `yarn format` - Resolve Style issues.
--   `yarn update` - Update dependencies (Use this if you are **really** sure what you're doing).
-
-.. _setup-typo3-installation:
-
-Setting up a Working TYPO3 Installation
-=======================================
-
-You will now need to use your git clone to setup a working installation
-of TYPO3. There are many different ways how you can do this. We
-provide a few examples in the Appendix:
-
-* :ref:`DDEV <settting-up-typo3-with-ddev>`
-* :ref:`setting-up-typo3-manually`
+         composer install


### PR DESCRIPTION
Add the commands for building with runTests.sh:

- runTests.sh -s composerInstall
- runTests.sh -s buildCss
- runTests.sh -s buildJavascript

The section on yarn was removed in the setup section. It is not
necessary to build the assets when setting up. It is only necessary
when changing SCSS or Typescript / JavaScript etc. Additionally,
it is planned to have a section with all build commands in the
Howto section. This makes it more appropriate to remove the part
in the setup section.

For all listed commands, we add TABs so that we can always show
the runTests.sh commands and the "direct commands" side by side.

This will hopefully make it less confusing for the readers.

It was also discussed to remove the direct commands entirely - however
there is sometimes still the need to use the direct command. In any
case it is always noted that runTests.sh is recommended.

Resolves: #249
Resolves: #254