### PR TITLE
Change codeblock to recommended style (4)

### DIFF
--- a/Documentation/AddingDocumentation/Index.rst
+++ b/Documentation/AddingDocumentation/Index.rst
@@ -171,7 +171,10 @@ Check Your `rst` File
 
 When your change is finished, you can run the following script to check that
 your rst file is ok. The script will check all files in
-:file:`typo3/sysext/core/Documentation/Changelog`::
+:file:`typo3/sysext/core/Documentation/Changelog`:
+
+.. code-block:: shell
+   :caption: shell command
 
    Build/Scripts/validateRstFiles.php
 
@@ -199,6 +202,7 @@ If you wish to render the Changelog locally, you can use docker as described
 in :ref:`h2document:rendering-docs-quickstart`.
 
 .. code-block:: bash
+   :caption: shell command
    :linenos:
 
    cd typo3/sysext/core/

--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -177,31 +177,44 @@ Relationships
    2. If you have multiple resolved or related issues, **use one line for each
       issue number**. Do not separate them by comma or alike!
 
-   ::
+   .. code-block:: text
+      :caption: commit message
 
       Resolves: #12345
       Resolves: #67890
 
 
 1. `Resolves:`
-   You need to reference an issue on Forge_ here simply by adding #[ISSUE_NUMBER]. For **features** and **tasks**, it closes the issue on merge.::
+   You need to reference an issue on Forge_ here simply by adding #[ISSUE_NUMBER]. For **features** and **tasks**, it closes the issue on merge.:
+
+   .. code-block:: text
+      :caption: commit message
 
       Resolves: #12345
 
    *Historical* : Some issues from the time since the introduction of GIT
    (March 1st 2011) and the migration of the bug tracker to Forge
    (March 29th 2011), still refer to Mantis bug tracker numbers, with a
-   prefix the number with an  *M* , i.e.::
+   prefix the number with an  *M* , i.e.:
+
+   .. code-block:: text
+      :caption: commit message
 
       Resolves: #M12345
 
 2. `Related:`
-   Other issues related to this change which are not resolved (for **all types**, it simply adds a relation, no closing). You need to reference an issue on Forge_ by just adding the issue number like in::
+   Other issues related to this change which are not resolved (for **all types**, it simply adds a relation, no closing). You need to reference an issue on Forge_ by just adding the issue number like in:
+
+   .. code-block:: text
+      :caption: commit message
 
       Related: #12345
 
 3. `Releases:`
-   This is a comma separated list of the target versions you intend to apply this fix on. In general, we **always** fix things on **main** first and then backport a change if it goes along with our support rules for older versions.. Example::
+   This is a comma separated list of the target versions you intend to apply this fix on. In general, we **always** fix things on **main** first and then backport a change if it goes along with our support rules for older versions.. Example:
+
+   .. code-block:: text
+      :caption: commit message
 
       Releases: main, 10.4, 9.5
 
@@ -209,7 +222,10 @@ Relationships
 
 4. `Depends`
    For TYPO3  **documentation patches**.
-   Refer to the corresponding TYPO3 Core patch::
+   Refer to the corresponding TYPO3 Core patch:
+
+   .. code-block:: text
+      :caption: commit message
 
       Depends: ChangeIdOfCorePatch
 

--- a/Documentation/Appendix/OSX/SSHKeyOSX.rst
+++ b/Documentation/Appendix/OSX/SSHKeyOSX.rst
@@ -82,11 +82,19 @@ it to your clipboard using the following command::
 
 Now you can head over to Gerrit_, go to settings and paste your public key as described :ref:`here<GerritAccount>`.
 
-Gerrit is using the special port `29418` instead of the default SSH port `22` which has to be configured accordingly. This can be done in your local `~/.ssh/config` file which would contain the following sections then::
+Gerrit is using the special port `29418` instead of the default SSH port `22`
+which has to be configured accordingly. This can be done in your local
+`~/.ssh/config` file which would contain the following sections then:
+
+.. code-block:: text
+   :caption: ~/.ssh/config
 
    Host review.typo3.org
       Port 29418
 
-Testing your connection::
+Testing your connection:
 
-      ssh -T <YOUR_TYPO3_USERNAME>@review.typo3.org
+.. code-block:: bash
+   :caption: shell command
+
+   ssh -T <YOUR_TYPO3_USERNAME>@review.typo3.org

--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -23,7 +23,10 @@ The following commands assume you are in the working directory of the TYPO3 core
 git clone
 =========
 
-Clone TYPO3 CMS Git repository into current directory::
+Clone TYPO3 CMS Git repository into current directory:
+
+.. code-block:: bash
+   :caption: shell command
 
    git clone git@github.com:typo3/typo3 .
 
@@ -39,30 +42,48 @@ Workflow - common commands
 
 For details see :ref:`Fixing-a-bug-A-Z`
 
-Reset repo to last remote commit in (remote) main branch::
+Reset repo to last remote commit in (remote) main branch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git reset --hard origin/main && git pull origin main
 
-Stage and commit all changes::
+Stage and commit all changes:
+
+.. code-block:: bash
+   :caption: shell command
 
    git commit -a
 
-Is the same as::
+Is the same as:
+
+.. code-block:: bash
+   :caption: shell command
 
    git add .
    git commit
 
-Stage and commit all changes to already existing commit::
+Stage and commit all changes to already existing commit:
+
+.. code-block:: bash
+   :caption: shell command
 
    git commit -a --amend
 
-Push changes to remote main branch on gerrit (default method)::
+Push changes to remote main branch on gerrit (default method):
+
+.. code-block:: bash
+   :caption: shell command
 
    git push
 
 This assumes, you have correctly configured your remote as described in
 :ref:`git-setup-remote`. If not, you must explicitly push using the
-`refs/for namespace <https://gerrit-review.googlesource.com/Documentation/concept-refs-for-namespace.html>`__::
+`refs/for namespace <https://gerrit-review.googlesource.com/Documentation/concept-refs-for-namespace.html>`__:
+
+.. code-block:: bash
+   :caption: shell command
 
    git push origin HEAD:refs/for/main
 
@@ -74,9 +95,12 @@ This assumes, you have correctly configured your remote as described in
 Workflow - work in progress
 ===========================
 
-In case you want to push a "Work in progress", use the following instead::
+In case you want to push a "Work in progress", use the following instead:
 
-      git push origin HEAD:refs/for/main%wip
+.. code-block:: bash
+   :caption: shell command
+
+   git push origin HEAD:refs/for/main%wip
 
 You can also configure Gerrit to always mark your pushes as WIP. In order to do this
 head over to https://review.typo3.org/settings/ and configure "Set new
@@ -89,15 +113,24 @@ See: https://gerrit-review.googlesource.com/Documentation/user-upload.html#wip
 Workflow -other branches
 ========================
 
-Show all branches::
+Show all branches:
+
+.. code-block:: bash
+   :caption: shell command
 
    git branch -a
 
-Checkout 10.4 branch::
+Checkout 10.4 branch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git checkout 10.4
 
-Checkout 9.5 branch::
+Checkout 9.5 branch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git checkout 9.5
 
@@ -112,11 +145,17 @@ Checkout 9.5 branch::
 Long story short: In most cases, **push to main**. The rest is being taken
 care of by core team members!
 
-Push 10.4 branch::
+Push 10.4 branch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git push origin HEAD:refs/for/10.4
 
-Push 9.5 branch::
+Push 9.5 branch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git push origin HEAD:refs/for/9.5
 
@@ -129,6 +168,7 @@ Details: :ref:`commitmessage`
 Example commit message for a bugfix:
 
 .. code-block:: text
+   :caption: commit message
 
    [BUGFIX] Subject line
 
@@ -155,20 +195,32 @@ Other keywords:
 Workflow - Undoing / fixing things
 ==================================
 
-Throw away all changes since last commit::
+Throw away all changes since last commit:
+
+.. code-block:: bash
+   :caption: shell command
 
    git reset HEAD --hard
 
-Unstage a file (remove file from index, but keep in working dir)::
+Unstage a file (remove file from index, but keep in working dir):
+
+.. code-block:: bash
+   :caption: shell command
 
    git reset <path>
 
-Change author for last commit::
+Change author for last commit:
+
+.. code-block:: bash
+   :caption: shell command
 
    git commit --amend --author "Some Name <some@email>"
 
 
-Squash last 2 commits::
+Squash last 2 commits:
+
+.. code-block:: bash
+   :caption: shell command
 
    git rebase -i HEAD~2
 

--- a/Documentation/DebuggingTypo3/Index.rst
+++ b/Documentation/DebuggingTypo3/Index.rst
@@ -34,7 +34,7 @@ php.ini
 
 Example setup:
 
-.. code-block:: text
+.. code-block:: ini
    :caption: php.ini
 
    xdebug.remote_enable = 1

--- a/Documentation/DebuggingTypo3/Index.rst
+++ b/Documentation/DebuggingTypo3/Index.rst
@@ -34,7 +34,8 @@ php.ini
 
 Example setup:
 
-::
+.. code-block:: text
+   :caption: php.ini
 
    xdebug.remote_enable = 1
    xdebug.remote_host = localhost

--- a/Documentation/HandlingAPatch/ChangeAPatch.rst
+++ b/Documentation/HandlingAPatch/ChangeAPatch.rst
@@ -41,7 +41,10 @@ This chapter handles improving an existing patch. For creating a new patch, see 
 5. Add files and amend to commit
 
    Update the change by **amending** the previous commit. This will overwrite
-   the commit you fetched from Gerrit with your changes::
+   the commit you fetched from Gerrit with your changes:
+
+   .. code-block:: bash
+      :caption: shell command
 
       git commit --amend -a
 
@@ -53,7 +56,9 @@ This chapter handles improving an existing patch. For creating a new patch, see 
 
 6. Push your change to Gerrit
 
-   Once you are satisfied, push your improved Patch Set to Gerrit::
+   Once you are satisfied, push your improved Patch Set to Gerrit:
 
+   .. code-block:: bash
+      :caption: shell command
 
       git push origin HEAD:refs/for/main

--- a/Documentation/HandlingAPatch/CleanupTypo3.rst
+++ b/Documentation/HandlingAPatch/CleanupTypo3.rst
@@ -14,7 +14,10 @@ Cleanup tasks
 Cleanup git repository
 ======================
 
-Before :ref:`Cherry-picking a patch <cherry-pick-a-patch>` or starting a new patch::
+Before :ref:`Cherry-picking a patch <cherry-pick-a-patch>` or starting a new patch:
+
+.. code-block:: bash
+   :caption: shell command
 
    git reset --hard origin/main
    git pull
@@ -34,6 +37,7 @@ any case or if in doubt, you can safely perform all steps.
 **Flush the cache**:
 
 .. code-block:: shell
+   :caption: shell command
 
    bin/typo3 cache:flush
 
@@ -42,7 +46,10 @@ Or via the install tool
 .. image:: /Images/ManualScreenshots/flush_cache.svg
    :class: with-shadow
 
-**Changes in composer.json**::
+**Changes in composer.json**:
+
+.. code-block:: shell
+   :caption: shell command
 
    composer install
 

--- a/Documentation/HandlingAPatch/Rebase.rst
+++ b/Documentation/HandlingAPatch/Rebase.rst
@@ -114,9 +114,8 @@ This command assumes, you are currently working on your patch
 in your local git repository and you have a clean working
 directory, meaning you committed your changes.
 
-**Do it:**
-
-::
+.. code-block:: bash
+   :caption: shell command
 
    git pull --rebase origin main
 
@@ -125,7 +124,8 @@ additional option `--rebase`.)
 
 or
 
-::
+.. code-block:: bash
+   :caption: shell command
 
    git fetch
    git rebase origin/main

--- a/Documentation/ReportingAnIssue/Index.rst
+++ b/Documentation/ReportingAnIssue/Index.rst
@@ -358,7 +358,8 @@ of the problem.
 
 **Example:**
 
-::
+.. code-block:: text
+   :caption: Redmine inline formatting
 
    !filename.png!
 
@@ -388,13 +389,15 @@ descriptive anchor text.
 
 **Syntax:**
 
-::
+.. code-block:: text
+   :caption: Redmine inline formatting
 
    "Anchor text":url
 
 **Example:**
 
-::
+.. code-block:: text
+   :caption: Redmine inline formatting
 
    "Forger search example":https://forger.typo3.com/search?query=really+long+query+string+with+filters&filters%5Btypo3_version%5D%5B8%5D=true&filters%5Bcategory%5D%5BLink_Handling_%26_Routing%5D=true
 

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -258,7 +258,7 @@ fill out the required information.
 
 First, create a file, for example :file:`~/.gitmessage.txt`.
 
-.. code-block:: none
+.. code-block:: text
    :caption: ~/.gitmessage.txt
 
    [BUGFIX|TASK|FEATURE]

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -309,7 +309,7 @@ The result should look like this:
 
 Or, compare the :file:`.git/config` file inside the repository:
 
-.. code-block:: none
+.. code-block:: ini
    :caption: .git/config
 
     [core]

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -25,23 +25,25 @@ Git Setup
    To switch from master to main:
 
    .. code-block:: bash
+      :caption: shell command
 
-       # Make sure that git pull loads from the "main" branch
-       git branch --set-upstream-to origin/main
+      # Make sure that git pull loads from the "main" branch
+      git branch --set-upstream-to origin/main
 
-       # Rename your current "master" branch locally to "main" to match TYPO3's naming scheme
-       git branch -m master main
+      # Rename your current "master" branch locally to "main" to match TYPO3's naming scheme
+      git branch -m master main
 
    Please also adapt your :ref:`commit message template <committemplate>`, if configured.
 
    If not using the GitHub remote yet, also change:
 
    .. code-block:: bash
+      :caption: shell command
 
-       # set remote url for "origin"
-       git remote set-url origin https://github.com/typo3/typo3.git
-       # set push URL to gerrit (this has not changed)
-       git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
+      # set remote url for "origin"
+      git remote set-url origin https://github.com/typo3/typo3.git
+      # set push URL to gerrit (this has not changed)
+      git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
 
 
    See
@@ -62,12 +64,18 @@ These steps will walk you through your basic Git setup when working with TYPO3.
 git clone
 =========
 
-Create a directory for your TYPO3 core installation and change into it, e.g.::
+Create a directory for your TYPO3 core installation and change into it, e.g.:
+
+.. code-block:: bash
+   :caption: shell command
 
    mkdir /var/www/t3coredev
    cd /var/www/t3coredev
 
-Clone the TYPO3 CMS core repository::
+Clone the TYPO3 CMS core repository:
+
+.. code-block:: bash
+   :caption: shell command
 
    git clone git@github.com:typo3/typo3 .
 
@@ -85,7 +93,11 @@ Set Username and Email
 *-- required* (unless this is already setup globally, see `git config --global -l`)
 
 You need to instruct git to work with your name and email address. Make sure the email address and user name are the same as those you used when
-:ref:`setting up your TYPO3 account<TYPO3Account>`::
+:ref:`setting up your TYPO3 account<TYPO3Account>`:
+
+.. code-block:: bash
+   :caption: shell command
+
 
    git config user.name "Your Name"
    git config user.email "your-email@example.org"
@@ -104,10 +116,12 @@ Set autosetuprebase
 *-- required*
 
 In order to avoid weird merges in your local repository when pulling in new commits from typo3.org, we encourage everybody
-to set the autosetuprebase option, such that your local commits are always rebased on top of the official code::
+to set the autosetuprebase option, such that your local commits are always rebased on top of the official code:
+
+.. code-block:: bash
+   :caption: shell command
 
    git config branch.autosetuprebase remote
-
 
 
 .. index::
@@ -134,7 +148,10 @@ commit-msg Hook
 
 *-- required*
 
-Activate the hook by copying the sample file to :file:`.git/hooks/commit-msg`::
+Activate the hook by copying the sample file to :file:`.git/hooks/commit-msg`:
+
+.. code-block:: bash
+   :caption: shell command
 
    # ensure folder exists
    mkdir -p .git/hooks
@@ -160,7 +177,10 @@ pre-commit Hook
 
 The pre-commit hook runs on Linux and MacOS. To use the pre-commit hook on Windows you can use a tool like the `Git BASH <https://gitforwindows.org/>`__.
 
-Activate the hook by copying the sample file to :file:`.git/hooks/pre-commit`::
+Activate the hook by copying the sample file to :file:`.git/hooks/pre-commit`:
+
+.. code-block:: bash
+   :caption: shell command
 
    # ensure folder exists
    mkdir -p .git/hooks
@@ -179,7 +199,10 @@ Alternative: Setup With Composer
 
 As an alternative for copying the hook scripts manually, you can use the following composer command:
 
-For Linux / MacOS::
+For Linux / MacOS:
+
+.. code-block:: bash
+   :caption: shell command
 
    composer gerrit:setup
 
@@ -199,14 +222,20 @@ Setting up Your Remote
 
 *-- required*
 
-You must instruct Git to push to Gerrit_ instead of the original repository. It acts as a kind of facade in front of Git::
+You must instruct Git to push to Gerrit_ instead of the original repository. It acts as a kind of facade in front of Git:
+
+.. code-block:: bash
+   :caption: shell command
 
    git config remote.origin.pushurl ssh://<YOUR_TYPO3_USERNAME>@review.typo3.org:29418/Packages/TYPO3.CMS.git
 
 
 This will instruct Git to push using the
 `refs/for namespace <https://gerrit-review.googlesource.com/Documentation/concept-refs-for-namespace.html>`__
-when you do `git push`::
+when you do `git push`:
+
+.. code-block:: bash
+   :caption: shell command
 
    git config remote.origin.push +refs/heads/main:refs/for/main
 
@@ -227,16 +256,20 @@ Git will use the template to create the commit message, which you can
 then modify in your editor. So use this, to make it easier for you to
 fill out the required information.
 
-First, create a file, for example in :file:`~/.gitmessage.txt`.
+First, create a file, for example :file:`~/.gitmessage.txt`.
 
 .. code-block:: none
+   :caption: ~/.gitmessage.txt
 
    [BUGFIX|TASK|FEATURE]
 
    Resolves: #
    Releases: main, 10.4
 
-Make Git use this file as a template for the commit message::
+Make Git use this file as a template for the commit message:
+
+.. code-block:: bash
+   :caption: shell command
 
    git config commit.template ~/.gitmessage.txt
 
@@ -252,11 +285,17 @@ Show Configuration
 
 *-- optional*
 
-Show current configuration::
+Show current configuration:
 
-  git config -l
+.. code-block:: bash
+   :caption: shell command
 
-The result should look like this::
+   git config -l
+
+The result should look like this:
+
+.. code-block:: none
+   :caption: result
 
    ...
    remote.origin.url=git@github.com:typo3/typo3
@@ -268,7 +307,10 @@ The result should look like this::
    commit.template=/path/to/.gitmessage.txt
    ...
 
-Or, compare the :file:`.git/config` file inside the repository::
+Or, compare the :file:`.git/config` file inside the repository:
+
+.. code-block:: none
+   :caption: .git/config
 
     [core]
        repositoryformatversion = 0

--- a/Documentation/Setup/UseStyleguide.rst
+++ b/Documentation/Setup/UseStyleguide.rst
@@ -30,7 +30,10 @@ Setup
 .. tip::
 
    Once the styleguide extension is activated, it is possible to create
-   (or delete) the pages via command line::
+   (or delete) the pages via command line:
+
+   .. code-block:: bash
+      :caption: shell command
 
       # show help
       bin/typo3 styleguide:generate -h

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -36,7 +36,10 @@ especially look in the beginning of the output for a description and the listing
 of dependencies, in the list under `-s` to show available commands and at
 the bottom of the output for examples.
 
-Show help::
+Show help:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh -h
 
@@ -134,7 +137,10 @@ of TYPO3 CMS **main** branch (as described in :ref:`setup`).
 composer install
 ----------------
 
-Run composer install::
+Run composer install:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh -s composerInstall
 
@@ -143,12 +149,18 @@ CGL check and fix
 
 Do Coding Guidelines checks and fix them.
 
-Check and fix. This applies the command only to the files in the latest commit::
+Check and fix. This applies the command only to the files in the latest commit:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh -s cglGit
 
 Check and do NOT fix. This applies the command only to the files in the latest
-commit::
+commit:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh -s cglGit -n
 
@@ -157,6 +169,7 @@ Run all unit tests
 ------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh
 
@@ -164,6 +177,7 @@ Run unit tests with xdebug (uses default port 9000)
 ---------------------------------------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    ./Build/Scripts/runTests.sh -x
 
@@ -171,6 +185,7 @@ Run specific unit tests with xdebug
 -----------------------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/runTests.sh -x <directory or file>
 
@@ -182,6 +197,7 @@ Run functional tests
 --------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    ./Build/Scripts/runTests.sh -s functional
 
@@ -189,6 +205,7 @@ Run functional tests with PostgreSQL
 ------------------------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    ./Build/Scripts/runTests.sh -s functional -d postgres
 
@@ -196,6 +213,7 @@ Run acceptance tests
 --------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    ./Build/Scripts/runTests.sh -s acceptance
 
@@ -211,13 +229,17 @@ with the additional `-v` (for verbose output) option.
 Before diagnosing problems in the script, make sure to check if
 Docker is running smoothly on your system.
 
-A quick test is to run the docker hello-world image::
+A quick test is to run the docker hello-world image:
+
+.. code-block:: bash
+   :caption: shell command
 
    docker run hello-world
 
 You should see something like this message:
 
-.. code-block:: none
+.. code-block:: text
+   :caption: result
 
    Hello from Docker!
    This message shows that your installation appears to be working correctly.
@@ -274,6 +296,7 @@ Run all unit tests
 ------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml
 
@@ -281,6 +304,7 @@ Run specific unit tests
 -----------------------
 
 .. code-block:: bash
+   :caption: shell command
 
    bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/UnitTests.xml <directory or file>
 
@@ -293,8 +317,9 @@ Run all functional tests
 ------------------------
 
 .. code-block:: bash
+   :caption: shell command
 
-  bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml
+   bin/phpunit -c vendor/typo3/testing-framework/Resources/Core/Build/FunctionalTests.xml
 
 
 
@@ -309,11 +334,17 @@ Check for Coding Guidelines
 
 The cgl checking commands / scripts not only check, they repair as well!
 
-Mac / Linux::
+Mac / Linux:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/cglFixMyCommit.sh
 
-Windows::
+Windows:
+
+.. code-block:: bash
+   :caption: shell command
 
    Build/Scripts/cglFixMyCommit.bat
 


### PR DESCRIPTION
Use recommended long form for code block style,
e.g. .. code-block:: bash instead of short form ::.

As documented, this is clearer.

Additionally, separate the command and result and use captions.

Remove the $ at the beginning of some commands as that was done
inconsistently and is usually not done elsewhere in this guide.

Resolves: #278