### PR TITLE
Move note about migrating Git setup

### DIFF
--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -37,6 +37,49 @@ Setup
 
 For detailed setup instructions, please see: :ref:`Setting-up-your-Git-environment`
 
+Migrations
+==========
+
+.. _migrate-master-main:
+
+Migrate master => main
+----------------------
+
+If you are using an older installation with the master branch you can switch
+like this from master to main:
+
+.. code-block:: bash
+   :caption: shell command
+
+   # Make sure that git pull loads from the "main" branch
+   git branch --set-upstream-to origin/main
+
+   # Rename your current "master" branch locally to "main" to match TYPO3's naming scheme
+   git branch -m master main
+
+Please also adapt your :ref:`commit message template <committemplate>` (if
+configured) to use "main" instead of "master".
+
+* `TYPO3 Core Development to Change Branch Name <https://typo3.org/article/typo3-core-development-to-change-branch-name>`__ (November 28, 2021)
+
+.. _migrateToGithub:
+
+Migrate to GitHub
+-----------------
+
+If you are working with an older t3coredev installation and are not using the
+GitHub URL yet, you can switch like this:
+
+.. code-block:: bash
+   :caption: shell command
+
+   # set remote url for "origin"
+   git remote set-url origin https://github.com/typo3/typo3.git
+   # set push URL to gerrit (this has not changed)
+   git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
+
+* `Renaming the TYPO3 GitHub Repository <https://typo3.org/article/renaming-the-typo3-github-repository>`__. (July 6, 2021)
+
 Workflow - common commands
 ==========================
 

--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -18,39 +18,11 @@ Git Setup
 
 .. note::
 
-   If you are working on a previously cloned, older repository, the TYPO3
-   repository URL changed to GitHub **and the branch "master" changed to "main".**
-   Existing repositories can be adapted like this:
+   If you are working on a previously cloned, older repository, you can skip
+   this page but may need to make the following changes to your Git setup:
 
-   To switch from master to main:
-
-   .. code-block:: bash
-      :caption: shell command
-
-      # Make sure that git pull loads from the "main" branch
-      git branch --set-upstream-to origin/main
-
-      # Rename your current "master" branch locally to "main" to match TYPO3's naming scheme
-      git branch -m master main
-
-   Please also adapt your :ref:`commit message template <committemplate>`, if configured.
-
-   If not using the GitHub remote yet, also change:
-
-   .. code-block:: bash
-      :caption: shell command
-
-      # set remote url for "origin"
-      git remote set-url origin https://github.com/typo3/typo3.git
-      # set push URL to gerrit (this has not changed)
-      git config remote.origin.pushurl "ssh://<your-username>@review.typo3.org:29418/Packages/TYPO3.CMS.git"
-
-
-   See
-
-   * `TYPO3 Core Development to Change Branch Name <https://typo3.org/article/typo3-core-development-to-change-branch-name>`__ (November 28, 2021)
-   * `Renaming the TYPO3 GitHub Repository <https://typo3.org/article/renaming-the-typo3-github-repository>`__. (July 6, 2021)
-
+   *  :ref:`migrate-master-main`
+   *  :ref:`migrateToGithub`
 
 These steps will walk you through your basic Git setup when working with TYPO3.
 


### PR DESCRIPTION
The note is moved from the Git setup to the cheatsheet and split
into 2 parts with individual sections.

This moves the information from the Git setup which is for new
people (but there is still a much shorter note with the links
in case someone is looking for this).

The problem was that the note was very look, and it was not
very clear to contributors that they do not need to execute
this.

Resolves: #287