### PR TITLE
Add ddev composer install command

### DIFF
--- a/Documentation/Setup/UseStyleguide.rst
+++ b/Documentation/Setup/UseStyleguide.rst
@@ -29,6 +29,12 @@ Setup
 
 .. tip::
 
+   .. code-block: bash
+      :caption: You may install EXT:styleguide with composer easily, e.g. with DDEV
+      
+      # install EXT:styleguide inside DDEV
+      ddev composer require typo3/cms-styleguide
+
    Once the styleguide extension is activated, it is possible to create
    (or delete) the pages via command line:
 


### PR DESCRIPTION
A new user might ask how to install EXT:styleguide during walkthrough the contribution guide.
So a note how to do this with ddev might help.