### PR TITLE
[TASK] Update examples from yarn to npm

### DIFF
--- a/Documentation/Appendix/OSX/InstallGrunt.rst
+++ b/Documentation/Appendix/OSX/InstallGrunt.rst
@@ -10,13 +10,13 @@
 GRUNT install on OSX
 ====================
 
-First off, make sure you installed **yarn** like described :ref:`here<osx-npm>`.
+First off, make sure you installed **npm** like described :ref:`here<osx-npm>`.
 
 In your Terminal app navigate to the folder that you cloned the TYPO3 source into. Switch into the ``Build`` folder and run
 
 .. code-block:: bash
 
-   yarn install
+   npm ci
 
 This will install Grunt as well a s couple of Task plugins we use in the TYPO3 core.
 To make sure grunt is running, run

--- a/Documentation/Appendix/OSX/InstallNpm.rst
+++ b/Documentation/Appendix/OSX/InstallNpm.rst
@@ -1,17 +1,16 @@
 .. include:: /Includes.rst.txt
 
 .. index::
-   single: OS X; Yarn installation
-   single: Yarn installation; OS X
+   single: OS X; Npm installation
+   single: Npm installation; OS X
 
 .. _osx-npm:
 
 ===================
-Yarn install on OSX
+Npm install on OSX
 ===================
 
-Head over to https://yarnpkg.com and download the OSX installer. It will detect your operating system version and will
-give you the right downloads right off the bat.
+Head over to https://docs.npmjs.com/cli/ and follow the install instructions.
 
 Once you have installed it, you can open up the Terminal app which is located under Applications/Utilities on your mac.
-Once in the terminal, type ``yarn -v`` to get the version number of yarn that is currently running on your machine.
+Once in the terminal, type ``npm -v`` to get the version number of npm that is currently running on your machine.

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -45,7 +45,7 @@ Prerequisites
 
 .. note::
 
-   Composer and yarn can run inside of DDEV, so there is no need to set them up locally.
+   Composer and npm can run inside of DDEV, so there is no need to set them up locally.
 
 *  You have cloned the TYPO3 git repository as described in :ref:`git-clone` and
    have switched to the directory which contains the local Git repository.
@@ -80,7 +80,7 @@ Set correct PHP version, for example
 
    php_version: "8.1"
 
-Add necessary packages for the :ref:`yarn build process <Yarn build process>`
+Add necessary packages for the npm build process,
 (only needed if you are working on assets):
 
 .. code-block:: yaml
@@ -147,12 +147,14 @@ now:
 
       .. code-block:: bash
 
-         ddev exec "cd Build && yarn install"
-         ddev exec "cd Build && yarn build"
+         ddev exec "cd Build && npm ci"
+         ddev exec "cd Build && npm run build"
 
 
       The first command is required once, the second (build) command is required after
       every change of a resource file.
+
+      Be aware that until TYPO3 11.5 yarn was used. 
 
 .. seealso::
 

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -280,7 +280,7 @@ To resolve the conflict, use the following workflow:
    :caption: shell command
 
    cd Build
-   yarn build
+   npm run build
    git add
    git add typo3/sysext/backend/Resources/Public/Css/backend.css
    git cherry-pick --continue


### PR DESCRIPTION
This changed in the TYPO3 Core in this commit:
https://github.com/TYPO3/typo3/commit/6575656a6d18b4ebd37e952a566afc0e47e275e5