### PR TITLE
Improve Cleanup explanation

### DIFF
--- a/Documentation/HandlingAPatch/CherryPick.rst
+++ b/Documentation/HandlingAPatch/CherryPick.rst
@@ -51,6 +51,12 @@ to cherry-pick it from the review system into your local git repository.
 
 4. Clean up your local repository
 
+   Save your local changes beforehand, if you have any.
+   
+   .. code-block:: bash
+
+      git stash save 'comment-your-changes'
+
    .. code-block:: bash
 
       git reset --hard origin/main


### PR DESCRIPTION
If you had local changes git reset --hard would delete them. Add information to stash changes before.