### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/AddingDocumentation/Index.rst
+++ b/Documentation/AddingDocumentation/Index.rst
@@ -246,8 +246,8 @@ them as commands in your IDE / editor.
 Policy for Changing the Main Documentation
 ==========================================
 
-Once a new TYPO3 release comes out, the main documentation (e.g. :doc:`t3coreapi:Index`,
-:doc:`t3tca:Index` etc.) must be updated.
+Once a new TYPO3 release comes out, the main documentation (e.g. :ref:`t3coreapi:start`,
+:ref:`t3tca:start` etc.) must be updated.
 
 The procedure is documented in :ref:`h2document:update-docs`.
 
@@ -264,7 +264,7 @@ directory in the respective system extension directory, e.g.
 :file:`typo3/sysext/form/Documentation`.
 
 Not all system extensions have their own documentation. Some documentation
-(e.g. for the system extension *core*) is maintained within the :doc:`t3coreapi:Index`.
+(e.g. for the system extension *core*) is maintained within the :ref:`t3coreapi:start`.
 
 If in doubt, ask in the **#typo3-cms-coredev** channel on Slack.
 

--- a/Documentation/Appendix/ResourcesForEditors/Index.rst
+++ b/Documentation/Appendix/ResourcesForEditors/Index.rst
@@ -11,7 +11,7 @@ Here, we list some resources that are useful when editing this manual:
 General information
 ===================
 
-* :doc:`h2document:Index` (official guide)
+* :ref:`h2document:start` (official guide)
 
 Resources for this guide
 ========================


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198