### PR TITLE
Add info on number of characters in nano for commit message

### DIFF
--- a/Documentation/Appendix/CommitMessage.rst
+++ b/Documentation/Appendix/CommitMessage.rst
@@ -166,6 +166,11 @@ Here you can go into detail about the how and why of the change. It should be br
 
 -  Wrap the lines after 72 characters manually
 
+.. note::
+
+   The default editor for git commit messages is `nano`. To display information on number of characters in `nano` create a file `~/.nanorc` and add the line `set constantshow`.
+
+
 Relationships
 -------------
 


### PR DESCRIPTION
This adds information on how to configure the git default editor `nano` to show information on number of characters for commit messages.

This fixes #305 