### PR TITLE
Fix URL for first install

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Manually.rst
+++ b/Documentation/Appendix/SettingUpTypo3Manually.rst
@@ -57,6 +57,8 @@ Create FIRST_INSTALL
 Continue ...
 ============
 
-You can now access the TYPO3 installation wizard by going to, e.g.
-http://t3coredev/typo3/. Follow the instructions of the installation
-wizard.
+You can now access the TYPO3 installation wizard by loading the page in the
+browser with the configured URL, e.g. http://t3coredev. This should redirect
+to http://t3coredev/typo3/install.php.
+
+Follow the instructions of the installation wizard.


### PR DESCRIPTION
The URL listed for first install was http://t3coredev/typo3. This is incorrect (at least for TYPO3 12.4) and also documented differently in installation section of "Getting started".

The URL should be just http://t3coredev which should redirect to http://t3coredev/typo3/install.php.

Resolves: #307