### PR TITLE
Remove orphan pages

### DIFF
--- a/Documentation/HandlingAPatch/Backporting.rst
+++ b/Documentation/HandlingAPatch/Backporting.rst
@@ -1,3 +1,0 @@
-:orphan:
-
-The page was moved to: :ref:`coreMergers-backport`

--- a/Documentation/HandlingAPatch/Revert.rst
+++ b/Documentation/HandlingAPatch/Revert.rst
@@ -1,3 +1,0 @@
-:orphan:
-
-The page was moved to: :ref:`coreMergers-revert`


### PR DESCRIPTION
These are empty pages where the content has already been removed 2 years ago.

Related: #255

---

See "git blame" for history (here we see the change was made 2 years ago which should be plenty of time to delete the page now): 

* https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-ContributionWorkflow/blame/main/Documentation/HandlingAPatch/Revert.rst
* https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-ContributionWorkflow/blame/main/Documentation/HandlingAPatch/Backporting.rst