### PR TITLE
Update note about COMPOSER_ROOT_VERSION

### DIFF
--- a/Documentation/Setup/SetupTypo3.rst
+++ b/Documentation/Setup/SetupTypo3.rst
@@ -1,35 +1,35 @@
-.. include:: /Includes.rst.txt
+..  include:: /Includes.rst.txt
 
-.. highlight:: bash
+..  highlight:: bash
 
-.. _setup-typo3:
-.. _setup-typo3-installation:
+..  _setup-typo3:
+..  _setup-typo3-installation:
 
 ============================
 Setup the TYPO3 installation
 ============================
 
-.. important::
+..  important::
 
-   If you are setting TYPO3 up with DDEV, you can skip this page and jump straight to
+    If you are setting TYPO3 up with DDEV, you can skip this page and jump straight to
 
-   .. rst-class:: horizbuttons-primary-m
+    .. rst-class:: horizbuttons-primary-m
 
-   - :ref:`DDEV <settting-up-typo3-with-ddev>`
+    - :ref:`DDEV <settting-up-typo3-with-ddev>`
 
 You will now need to setup a working installation
 of TYPO3. There are different ways how you can do this. We
 provide a few examples in the Appendix:
 
-* :ref:`DDEV <settting-up-typo3-with-ddev>`
-* :ref:`setting-up-typo3-manually`
+*   :ref:`DDEV <settting-up-typo3-with-ddev>`
+*   :ref:`setting-up-typo3-manually`
 
 In any case, use the cloned Git repository as basis (see :ref:`git-clone`).
 
-.. index::
-   single: Code Contribution Workflow; composer install
+..  index::
+    single: Code Contribution Workflow; composer install
 
-.. _composer-install:
+..  _composer-install:
 
 composer install
 ================
@@ -41,33 +41,31 @@ It is recommended to use runTests.sh for this. The "direct command" is an
 alternative. You only need to run one of these!
 
 
-.. note::
+..  note::
 
-   This is **no longer necessary for the current main branch**, but may be necessary
-   for older version (if working in other branches) (see related
-   `issue <https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-ContributionWorkflow/issues/254>`__).
-   Composer could not detect the TYPO3 version of your cloned project because there was none. Before you run
-   `composer install` may need to export the `COMPOSER_ROOT_VERSION environment variable <https://getcomposer.org/doc/03-cli.md#composer-root-version>`__.
-   Here you need to set a full version string matching the TYPO3 version of your clone.
+    While working with the TYPO3 sources composer can not detect the TYPO3 version of your
+    cloned project because there was none. Before you run `composer install` may need to export
+    the `COMPOSER_ROOT_VERSION environment variable <https://getcomposer.org/doc/03-cli.md#composer-root-version>`__.
+    Here you need to set a full version string matching the TYPO3 version of your clone.
 
-   Example:
+    Example:
 
-   .. code-block:: bash
+    ..  code-block:: bash
 
-      # cd <cloned project>
-      export COMPOSER_ROOT_VERSION=12.0.0
+        # cd <cloned project>
+        export COMPOSER_ROOT_VERSION=12.0.0
 
 
-.. tabs::
+..  tabs::
 
-   .. group-tab:: runTests.sh
+    ..  group-tab:: runTests.sh
 
-      .. code-block:: bash
+        ..  code-block:: bash
 
-         Build/Scripts/runTests.sh -s composerInstall
+            Build/Scripts/runTests.sh -s composerInstall
 
-   .. group-tab:: direct command
+   ..  group-tab:: direct command
 
-      .. code-block:: bash
+       ..  code-block:: bash
 
-         composer install
+           composer install


### PR DESCRIPTION
The info that this environment is not necessary anymore for TYPO3 13 is wrong. I can't install TYPO3 13 without. Helmut Hummel confirmed that this part is wrong here: https://typo3.slack.com/archives/C028J3N83/p1692115206971629