### PR TITLE
[DOCS] Mention HTTPS as alternative way of cloning from GitHub

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -46,10 +46,25 @@ Create a directory for your TYPO3 core installation and change into it, e.g.:
 
 Clone the TYPO3 CMS core repository:
 
-.. code-block:: bash
-   :caption: shell command
+.. tabs::
 
-   git clone git@github.com:typo3/typo3 .
+    .. group-tab:: SSH
+
+        Use the SSH clone method if you've added your SSH key to your GitHub account:
+
+        .. code-block:: bash
+           :caption: shell command
+
+           git clone git@github.com:typo3/typo3 .
+
+    .. group-tab:: HTTPS
+
+        As an alternative, you can always use the HTTPS clone method:
+
+        .. code-block:: bash
+           :caption: shell command
+
+           https://github.com/typo3/typo3.git .
 
 
 


### PR DESCRIPTION
Since not every contributor may have his SSH key added to GitHub, we should promote an alternative way of cloning. This should not make any difference in the contribution workflow, because it's actually not required to have an SSH key added to GitHub, because we're pushing to Gerrit instead.