### PR TITLE
[BUGFIX] Add missing `git clone` command

### DIFF
--- a/Documentation/Setup/Git/Index.rst
+++ b/Documentation/Setup/Git/Index.rst
@@ -64,7 +64,7 @@ Clone the TYPO3 CMS core repository:
         .. code-block:: bash
            :caption: shell command
 
-           https://github.com/typo3/typo3.git .
+           git clone https://github.com/typo3/typo3.git .
 
 
 


### PR DESCRIPTION
Follow-up to #322: The HTTPS clone command misses the `git clone` command. This is now fixed.