### PR TITLE
Fix broken link to git cheat sheets on GitHub

### DIFF
--- a/Documentation/CheatSheets/Git.rst
+++ b/Documentation/CheatSheets/Git.rst
@@ -280,7 +280,7 @@ References
 See also these not TYPO3 specific cheat sheets for git if you are not very familiar with git:
 
 * `cheat sheet for git
-  <https://services.github.com/on-demand/downloads/github-git-cheat-sheet/>`__
+  <https://training.github.com/>`__
   (in several languages)
 * `"git - the simple guide" by Roger Dudler <http://rogerdudler.github.io/git-guide/>`__
 * `"Oh, shit, git!" by Katie Sylor-Miller <https://ohshitgit.com/>`__ is basically a cheat sheet for Git, but


### PR DESCRIPTION
The link results in a 404. https://training.github.com/ Could be used instead.