### PR TITLE
fix ddev command for generating styleguide pages

### DIFF
--- a/Documentation/Setup/UseStyleguide.rst
+++ b/Documentation/Setup/UseStyleguide.rst
@@ -55,7 +55,7 @@ Setup
       bin/typo3 styleguide:generate -c
 
       # or (with DDEV)
-      ddev exec bin/typo3 styleguide:generate -c
+      ddev exec vendor/bin/typo3 styleguide:generate -c
 
 .. rst-class:: bignums-xxl
 


### PR DESCRIPTION
The path to the typo3 binary in the ddev command is wrong. this should fix it so that you can just copy the command 