### PR TITLE
Update SettingUpTypo3Ddev.rst

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -150,7 +150,7 @@ now:
          ddev exec "cd Build && npm ci"
          ddev exec "cd Build && npm run build"
 
-.. group-tab:: runTests.sh
+    .. group-tab:: runTests.sh
 
       .. code-block:: bash
 

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -150,7 +150,7 @@ now:
          ddev exec "cd Build && npm ci"
          ddev exec "cd Build && npm run build"
 
-    .. group-tab:: runTests.sh
+   .. group-tab:: runTests.sh
 
       .. code-block:: bash
 

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -124,17 +124,17 @@ using the instructions in :ref:`run-tests-directly-without-docker`.
 
 .. tabs::
 
-   .. group-tab:: runTests.sh
-
-      .. code-block:: bash
-
-         Build/Scripts/runTests.sh -s composerInstall
-
    .. group-tab:: DDEV
 
       .. code-block:: bash
 
          ddev composer install
+
+   .. group-tab:: runTests.sh
+
+      .. code-block:: bash
+
+         Build/Scripts/runTests.sh -s composerInstall
 
 
 The following is not necessary for the initial build, but once you change some assets (for example
@@ -143,19 +143,20 @@ now:
 
 .. tabs::
 
-   .. group-tab:: runTests.sh
-
-      .. code-block:: bash
-
-         Build/Scripts/runTests.sh -s buildCss
-         Build/Scripts/runTests.sh -s buildJavascript
-
    .. group-tab:: DDEV
 
       .. code-block:: bash
 
          ddev exec "cd Build && npm ci"
          ddev exec "cd Build && npm run build"
+
+.. group-tab:: runTests.sh
+
+      .. code-block:: bash
+
+         Build/Scripts/runTests.sh -s buildCss
+         Build/Scripts/runTests.sh -s buildJavascript
+
 
 
 The first command is required once, the second (build) command is required after


### PR DESCRIPTION
Since we are on the page "Setting up TYPO3 WITH DDEV" it is misleading to not see the ddev commands directly in the tab container, so I changed the tab ordering so that the user sees the ddev command first.

Best Regards, MT