### PR TITLE
Update SettingUpTypo3Ddev.rst

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -82,7 +82,7 @@ or edit the configuration file :file:`.ddev/config.yaml` manually.
 
     # Add necessary packages for the npm build process,
     # (only needed if you are working on assets):
-    ddev config --nodejs-version="18"
+    ddev config --nodejs-version="22"
     ddev config --webimage-extra-packages="automake,build-essential"
 
 Optionally, set a new HTTP/HTTPS port to avoid conflicts with local defaults.


### PR DESCRIPTION
Asset development for v13 now requires alt least node >=22