### PR TITLE
[TASK] Activate all required extensions

### DIFF
--- a/Documentation/Quickstart/5-TYPO3.rst
+++ b/Documentation/Quickstart/5-TYPO3.rst
@@ -67,6 +67,7 @@ Quick Start: Set up TYPO3
         :caption: **Ensure extension setup and activate EXT:styleguide**
 
         ddev typo3 extension:setup && \
+            ddev typo3 extension:activate indexed_search && \
             ddev typo3 extension:activate styleguide
 
     ..  code:: bash

--- a/Documentation/Quickstart/5-TYPO3.rst
+++ b/Documentation/Quickstart/5-TYPO3.rst
@@ -64,7 +64,7 @@ Quick Start: Set up TYPO3
 3.  Activate `EXT:styleguide`
 
     ..  code:: bash
-        :caption: **Ensure extension setup and activate EXT:styleguide**
+        :caption: **Ensure extension setup and activate required extensions (EXT:styleguide, EXT:indexed_search)**
 
         ddev typo3 extension:setup && \
             ddev typo3 extension:activate indexed_search && \


### PR DESCRIPTION
This change modifies the `QuickStart: Set up TYPO3`
section to activate the mandantory system extension
`indexed_search` along with `styleguide` to reflect
latest dependency chain.