### PR TITLE
Correct the command to build javascript from typescript

### DIFF
--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -255,7 +255,7 @@ Luckily, `runTests.sh` also helps us to build JavaScript and CSS assets:
 
 ..  code-block:: shell
 
-    Build/Scripts/runTests.sh -s buildJavaScript
+    Build/Scripts/runTests.sh -s buildJavascript
     Build/Scripts/runTests.sh -s buildCss
 
 Again, this utilizes all the needed containers for the proper NodeJS environment, so you have


### PR DESCRIPTION
The command given in the document does not exist and shows help instead. The issue is with the case of the command. It has to be buildJavascript and not buildJavaScript. See:

```shell
$ Build/Scripts/runTests.sh -s buildJavaScript
Invalid -s option argument buildJavaScript

TYPO3 core test runner. Execute acceptance, unit, functional and other test suites in
a container based test environment. Handles execution of single test files, sending
xdebug information to a local IDE and more.

Usage: Build/Scripts/runTests.sh [options] [file]

Options:
    -s <...>
        Specifies the test suite to run
            - acceptance: main application acceptance tests
            - acceptanceComposer: main application acceptance tests
            - acceptanceInstall: installation acceptance tests, only with -d mariadb|postgres|sqlite
            - buildCss: execute scss to css builder
            - buildJavascript: execute typescript to javascript builder
```