### PR TITLE
Correct Push to Gerrit output

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -161,11 +161,12 @@ as described in :ref:`setup <setup>` (or via the
    .. code-block:: none
       :caption: result
 
-      remote: New Changes:
-      remote:   https://review.typo3.org/<gerrit-id>
+      remote: SUCCESS
       remote:
-      To ssh://<username>@review.typo3.org:29418/Packages/TYPO3.CMS.git
-       * [new branch]      HEAD -> refs/for/<release-branch>
+      remote:   https://review.typo3.org/c/Packages/TYPO3.CMS/+/<gerrit-id> [...] ... [NEW]
+      remote:
+      To ssh://review.typo3.org:29418/Packages/TYPO3.CMS.git
+      * [new reference]         main -> refs/for/main
 
    If you see an error, check out the :ref:`Git Troubleshooting <git-troubleshooting>`
    section.


### PR DESCRIPTION
Hi :)

the "git push" to Gerrit output on this page ( https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/BugfixingAZ/Index.html ) is incorrect.

```
remote: New Changes:
remote:   https://review.typo3.org/<gerrit-id>
remote:
To ssh://<username>@review.typo3.org:29418/Packages/TYPO3.CMS.git
 * [new branch]      HEAD -> refs/for/<release-branch>
```

This doesn't create a branch but a reference.
So I think it should be similar as the output displayed in the quickstart part of the guide ( https://docs.typo3.org/m/typo3/guide-contributionworkflow/main/en-us/Quickstart/6-Patch.html )

```
remote: SUCCESS
remote:
remote:   https://review.typo3.org/c/Packages/TYPO3.CMS/+/85025 [TASK] Add HTML5 spec "input-type='json'" to TCA type=json [NEW]
remote:
To ssh://review.typo3.org:29418/Packages/TYPO3.CMS.git
* [new reference]         main -> refs/for/main
```

This PR tries to fix that.