### PR TITLE
[TASK] Quickstart - Fix missing "-s" parameter in "Reset to current upstream state" commands list

### DIFF
--- a/Documentation/BugfixingAZ/Index.rst
+++ b/Documentation/BugfixingAZ/Index.rst
@@ -161,11 +161,12 @@ as described in :ref:`setup <setup>` (or via the
    .. code-block:: none
       :caption: result
 
-      remote: New Changes:
-      remote:   https://review.typo3.org/<gerrit-id>
+      remote: SUCCESS
       remote:
-      To ssh://<username>@review.typo3.org:29418/Packages/TYPO3.CMS.git
-       * [new branch]      HEAD -> refs/for/<release-branch>
+      remote:   https://review.typo3.org/c/Packages/TYPO3.CMS/+/<gerrit-id> [...] ... [NEW]
+      remote:
+      To ssh://review.typo3.org:29418/Packages/TYPO3.CMS.git
+      * [new reference]         main -> refs/for/main
 
    If you see an error, check out the :ref:`Git Troubleshooting <git-troubleshooting>`
    section.

--- a/Documentation/Quickstart/7-Contribute.rst
+++ b/Documentation/Quickstart/7-Contribute.rst
@@ -42,7 +42,7 @@ With your environment, you can:
             git reset --hard origin/main && \
             git pull --rebase && \
             ./Build/Scripts/runTests.sh -u && \
-            ./Build/Scripts/runTests.sh composerInstall && \
+            ./Build/Scripts/runTests.sh -s composerInstall && \
             ddev typo3 cache:flush && \
             ddev typo3 cache:warmup && \
             ddev typo3 extension:setup


### PR DESCRIPTION
Added the missing "-s" in "runTests.sh composerInstall" command