### PR TITLE
Fix command for running changelog setup

### DIFF
--- a/Documentation/Quickstart/7-Contribute.rst
+++ b/Documentation/Quickstart/7-Contribute.rst
@@ -91,7 +91,7 @@ With your environment, you can:
     ..  code:: bash
         :caption: **Ensure working state for checkout change**
 
-        ./Build/Scripts/runTests.sh composerInstall && \
+        ./Build/Scripts/runTests.sh -s composerInstall && \
             ddev typo3 cache:flush && \
             ddev typo3 cache:warmup && \
             ddev typo3 extension:setup


### PR DESCRIPTION
The option flag `-s` was missing for the command. Without it, the command does not recognize `composerInstall` to be an option for the command.