### PR TITLE
[TASK] Prevent using "no/low brainer" as wording

### DIFF
--- a/Documentation/CoreMergers/Backport.rst
+++ b/Documentation/CoreMergers/Backport.rst
@@ -61,7 +61,7 @@ First try to use the Gerrit cherry-pick feature for automatic backporting.
 
 #. Merge the backport
 
-   If the backport is a :ref:`Low brainer <Gerrit-low-brainers>` you can vote
+   If the backport is straight-forward and not complex, you can vote
    :guilabel:`+2` and continue to merge the backport. Otherwise it should be
    reviewed by at least one other Core Merger.
 

--- a/Documentation/CoreMergers/Backport.rst
+++ b/Documentation/CoreMergers/Backport.rst
@@ -61,7 +61,7 @@ First try to use the Gerrit cherry-pick feature for automatic backporting.
 
 #. Merge the backport
 
-   If the backport is straight-forward and not complex, you can vote
+   If the backport is :ref:`straight-forward and not complex <Gerrit-low-complexity>`, you can vote
    :guilabel:`+2` and continue to merge the backport. Otherwise it should be
    reviewed by at least one other Core Merger.
 

--- a/Documentation/CoreMergers/Review.rst
+++ b/Documentation/CoreMergers/Review.rst
@@ -73,6 +73,7 @@ there is already a positive vote by another Core Merger.
 
 .. _Gerrit-No-brainers:
 .. _Gerrit-Low-brainers:
+.. _Gerrit-Low-complexity:
 
 Patches of low complexity
 -------------------------

--- a/Documentation/CoreMergers/Review.rst
+++ b/Documentation/CoreMergers/Review.rst
@@ -74,12 +74,12 @@ there is already a positive vote by another Core Merger.
 .. _Gerrit-No-brainers:
 .. _Gerrit-Low-brainers:
 
-Low brainers
--------------
+Patches of low complexity
+-------------------------
 
-A Core Merger can give a +2 and submit right away in case of "low-brainers"
-(what used to be called "FYI" and relates to changes that are highly
-unlikely to negatively impact anything).
+A Core Merger can give a +2 and submit right away in case of patches
+that are of very low complexity (like spelling corrections, indentation,
+or obvious bugs), and are highly unlikely to negatively impact anything.
 
 A Core Merger can give a +2 and wait a bit before submitting
 (used to be called "FYI24", "FYI48", ...).


### PR DESCRIPTION
To quote a post on the typo3-cms-coredev slack on the intentions of this, which I fully support:

There is nothing like a “no-brainer” or "low-brainer". Every patch needs to be checked thoroughly.
The word “no-brainer” leads to hasty mergers.
There is a reason why something has to be changed or adapted. If a change is so obvious, it would have been solved correctly from the very beginning. There is always a chance that the “no-brainer” is broken anyway. Please let us use our brains, always. Thank you.