### PR TITLE
[TASK] Adapt DDEV instructions to use apache-fpm and locales-all

### DIFF
--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -80,10 +80,14 @@ or edit the configuration file :file:`.ddev/config.yaml` manually.
     # Set correct PHP version:
     ddev config --php-version="8.2"
 
+    # Change to Apache webserver because using htaccess rules works out of the TYPO3-box
+    # and needs no custom NGINX configuration
+    ddev config --webserver-type 'apache-fpm'
+
     # Add necessary packages for the npm build process,
     # (only needed if you are working on assets):
     ddev config --nodejs-version="22"
-    ddev config --webimage-extra-packages="automake,build-essential"
+    ddev config --webimage-extra-packages="automake,build-essential,locales-all"
 
 Optionally, set a new HTTP/HTTPS port to avoid conflicts with local defaults.
 Error message:

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -78,16 +78,16 @@ or edit the configuration file :file:`.ddev/config.yaml` manually.
 .. code-block:: shell
 
     # Set correct PHP version:
-    ddev config --php-version="8.2"
+    ddev config --php-version='8.2'
 
     # Change to Apache webserver because using htaccess rules works out of the TYPO3-box
     # and needs no custom NGINX configuration
-    ddev config --webserver-type 'apache-fpm'
+    ddev config --webserver-type='apache-fpm'
 
     # Add necessary packages for the npm build process,
     # (only needed if you are working on assets):
-    ddev config --nodejs-version="22"
-    ddev config --webimage-extra-packages="automake,build-essential,locales-all"
+    ddev config --nodejs-version='22'
+    ddev config --webimage-extra-packages='automake,build-essential,locales-all'
 
 Optionally, set a new HTTP/HTTPS port to avoid conflicts with local defaults.
 Error message:
@@ -95,8 +95,8 @@ Failed to start t3coredev: Unable to listen on required ports, port 80 is alread
 
 .. code-block:: yaml
 
-   ddev config --router-http-port="8090"
-   ddev config --router-https-port="8443"
+   ddev config --router-http-port='8090'
+   ddev config --router-https-port='8443'
 
 Start DDEV
 ==========

--- a/Documentation/HandlingIssues/TicketWorkflow.rst
+++ b/Documentation/HandlingIssues/TicketWorkflow.rst
@@ -141,7 +141,7 @@ Status
 
    The upside: The patch that has been made may apply to your own instance.
    You can always download patches and apply them locally, see
-   :ref:`Applying Core patches <t3upgrade:applying-core-patches>` for details.
+   :ref:`Applying Core patches <t3coreapi:applying-core-patches>` for details.
 
 #. Closed
 

--- a/Documentation/Quickstart/4-DDEV.rst
+++ b/Documentation/Quickstart/4-DDEV.rst
@@ -38,7 +38,7 @@ Quick Start: Set up DDEV
             \
             --timezone 'Europe/Berlin' \
             --web-environment='TYPO3_CONTEXT=Development' \
-            --webimage-extra-packages='build-essential'
+            --webimage-extra-packages='build-essential,locales-all'
 
     Adapt parameters as wanted.
 

--- a/Documentation/Quickstart/4-DDEV.rst
+++ b/Documentation/Quickstart/4-DDEV.rst
@@ -22,21 +22,21 @@ Quick Start: Set up DDEV
         :caption: **Create a suitable ddev configuration**
 
         ddev config \
-            --project-name 't3c-main' \
-            --project-type 'typo3' \
-            --docroot '.' \
-            --database 'mariadb:10.11' \
-            --php-version '8.2' \
-            --composer-version 'stable' \
-            --nodejs-version '22' \
+            --project-name='t3c-main' \
+            --project-type='typo3' \
+            --docroot='.' \
+            --database='mariadb:10.11' \
+            --php-version='8.2' \
+            --composer-version='stable' \
+            --nodejs-version='22' \
             \
-            --project-tld 'ddev.site' \
-            --router-http-port '80' \
-            --router-https-port '443' \
-            --webserver-type 'apache-fpm' \
-            --additional-hostnames 't3c-dev.ddev.site,t3c-prod.ddev.site' \
+            --project-tld='ddev.site' \
+            --router-http-port='80' \
+            --router-https-port='443' \
+            --webserver-type='apache-fpm' \
+            --additional-hostnames='t3c-dev.ddev.site,t3c-prod.ddev.site' \
             \
-            --timezone 'Europe/Berlin' \
+            --timezone='Europe/Berlin' \
             --web-environment='TYPO3_CONTEXT=Development' \
             --webimage-extra-packages='build-essential,locales-all'
 


### PR DESCRIPTION
The "long form" DDEV guide is missing to utilize "apache-fpm", the default nginx setup does not provide all needed TYPO3 directives, and htaccess can do that more easily.

Drive-by adjustments: Unify usage of "--config-option='config-value'" and also add 'locales-all' as a package due to the merge of DDEV https://github.com/ddev/ddev/pull/6570