### PR TITLE
[TASK] Adapt JS+CSS build to patch #106501

### DIFF
--- a/Documentation/Appendix/OSX/InstallGrunt.rst
+++ b/Documentation/Appendix/OSX/InstallGrunt.rst
@@ -21,7 +21,7 @@ In your Terminal app navigate to the folder that you cloned the TYPO3 source int
 
 .. code-block:: bash
 
-   npm ci
+   npm install
 
 This will install Grunt as well a s couple of Task plugins we use in the TYPO3 core.
 To make sure grunt is running, run

--- a/Documentation/Appendix/SettingUpTypo3Ddev.rst
+++ b/Documentation/Appendix/SettingUpTypo3Ddev.rst
@@ -147,19 +147,28 @@ now:
 
 .. tabs::
 
+   .. group-tab:: locally
+
+      .. code-block:: bash
+
+         cd Build
+         nvm use
+         npm install
+         npm run build
+         // or: npm run watch:build
+
    .. group-tab:: DDEV
 
       .. code-block:: bash
 
-         ddev exec "cd Build && npm ci"
+         ddev exec "cd Build && npm install"
          ddev exec "cd Build && npm run build"
 
    .. group-tab:: runTests.sh
 
       .. code-block:: bash
 
-         Build/Scripts/runTests.sh -s buildCss
-         Build/Scripts/runTests.sh -s buildJavascript
+         Build/Scripts/runTests.sh -s build
 
 
 

--- a/Documentation/Build/Index.rst
+++ b/Documentation/Build/Index.rst
@@ -26,8 +26,9 @@ If you make changes to the source files, you can build locally using
 
 .. code-block:: bash
 
-   Build/Scripts/runTests.sh -s buildCss
-   Build/Scripts/runTests.sh -s buildJavascript
+   Build/Scripts/runTests.sh -s build
+
+Note you can also use `npm` + `nvm` locally, if you are proficient with setting this up locally.
 
 It is also possible to lint the files locally:
 

--- a/Documentation/HandlingAPatch/CleanupTypo3.rst
+++ b/Documentation/HandlingAPatch/CleanupTypo3.rst
@@ -57,8 +57,7 @@ Also you may need to create the JS/CSS assets:
 
 ..  code-block:: bash
 
-    ./Build/Scripts/runTests.sh -s buildCss && \
-        ./Build/Scripts/runTests.sh -s buildJavascript
+    ./Build/Scripts/runTests.sh -s build
 
 **Changes in DB schema (ext_tables.sql)**:
 

--- a/Documentation/HandlingAPatch/ResolveMergeConflicts.rst
+++ b/Documentation/HandlingAPatch/ResolveMergeConflicts.rst
@@ -240,8 +240,7 @@ JavaScript and CSS assets are build from sources in the monorepo, with the comma
    # optionally, reset state
    Build/Scripts/runTests.sh -s clean
 
-   Build/Scripts/runTests.sh -s buildCss
-   Build/Scripts/runTests.sh -s buildJavascript
+   Build/Scripts/runTests.sh -s build
 
 This "compiles" files with ".scss" and ".ts" extensions to their bundled ".css" and
 ".js" variants. TYPO3 also versions these files inside the monorepo.
@@ -254,7 +253,7 @@ will occur, if your patch works on anything CSS/JS related and other changes
 have been introduced meanwhile.
 
 The solution to resolve merge conflicts in these files is actually vers easy. Just
-re-perform the commands from above (`...buildCss/buildJavascript`), which will re-create
+re-perform the commands from above (`... build`), which will re-create
 the assets from your cherry-picked patchset. You may need to resolve conflicts in the
 `.ts/.scss` files beforehand, if there are any due to rebasing.
 

--- a/Documentation/Testing/CoreTesting.rst
+++ b/Documentation/Testing/CoreTesting.rst
@@ -255,8 +255,7 @@ Luckily, `runTests.sh` also helps us to build JavaScript and CSS assets:
 
 ..  code-block:: shell
 
-    Build/Scripts/runTests.sh -s buildJavascript
-    Build/Scripts/runTests.sh -s buildCss
+    Build/Scripts/runTests.sh -s build
 
 Again, this utilizes all the needed containers for the proper NodeJS environment, so you have
 zero local dependencies on properly building.

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -99,7 +99,7 @@ which start with the same string.
 Commands for building:
 
 *  `-s composerInstall`: install composer dependencies from `composer.lock`
-*  -s build: build CSS+JS assets
+*  `-s build`: build CSS+JS assets
 * ...
 
 Checks and fixes, run static analyzer, lint etc:

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -98,7 +98,7 @@ which start with the same string.
 
 Commands for building:
 
-*  -s composerInstall (composer*)
+*  `-s composerInstall`: install composer dependencies from `composer.lock`
 *  -s build: build CSS+JS assets
 * ...
 

--- a/Documentation/Testing/Index.rst
+++ b/Documentation/Testing/Index.rst
@@ -84,8 +84,7 @@ Output example:
         Specifies which test suite to run
             - acceptance: main application acceptance tests
             - acceptanceInstall: installation acceptance tests, only with -d mariadb|postgres|sqlite
-            - buildCss: execute scss to css builder
-            - buildJavascript: execute typescript to javascript builder
+            - build: execute frontend build (TypeScript, Sass, Contrib, Assets)
             - cgl: test and fix all core php files
    ...
 
@@ -100,8 +99,7 @@ which start with the same string.
 Commands for building:
 
 *  -s composerInstall (composer*)
-*  -s buildCss: build CSS assets
-*  -s buildJavascript
+*  -s build: build CSS+JS assets
 * ...
 
 Checks and fixes, run static analyzer, lint etc:

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -293,8 +293,7 @@ re-create the assets using the following workflow:
    ./Build/Scripts/runTests.sh -s clean
 
    # Execute the build
-   ./Build/Scripts/runTests.sh -s buildCss
-   ./Build/Scripts/runTests.sh -s buildJavascript
+   ./Build/Scripts/runTests.sh -s build
 
    # Now add all conflicting files as resolved:
    git add typo3/sysext/backend/Resources/Public/Css/backend.css


### PR DESCRIPTION
With https://review.typo3.org/c/Packages/TYPO3.CMS/+/88921 the 'buildJavascript' and 'buildCss' methods were aliased to 'build', which does the same but combined and quickly enough.

Adjust all references to this.