### PR TITLE
Fix tip rendering in "use EXT:styleguide" section

### DIFF
--- a/Documentation/Setup/UseStyleguide.rst
+++ b/Documentation/Setup/UseStyleguide.rst
@@ -42,8 +42,8 @@ Setup
 ..  rst-class:: bignums-xxl
 
 1.  Activate the styleguide extension in the Extension Manager
-    ..  tip::
 
+    ..  tip::
         Once the styleguide extension is activated, it is possible to create
         (or delete) the pages via command line:
 


### PR DESCRIPTION
While my last code style cleanup I have crashed `.. tip::` rendering in "use EXT:styleguide" section.