### PR TITLE
Delete unsupported plugin

### DIFF
--- a/Documentation/Appendix/IdePhpStormSetup.rst
+++ b/Documentation/Appendix/IdePhpStormSetup.rst
@@ -112,14 +112,6 @@ Recommended Plugins
 -------------------
 
 *   `EditorConfig plugin <https://plugins.jetbrains.com/plugin/7294-editorconfig>`__
-*   `DynamicReturnTypePlugin
-    <https://plugins.jetbrains.com/plugin/7251-dynamicreturntypeplugin>`__ :
-    With this Plugin, return types for some functions can be configured
-    dynamically. For example, if you use `GeneralUtility::makeInstance`,
-    the expected return type is determined from the first parameter
-    passed to the function. The configuration file for this plugin is
-    `dynamicReturnTypeMeta.json
-    <https://github.com/typo3/typo3/blob/main/dynamicReturnTypeMeta.json>`__
 *   `Php Inspections (EA Extended)
     <https://plugins.jetbrains.com/plugin/7622-php-inspections-ea-extended->`__ :
     Static Code Analysis tool for PHP


### PR DESCRIPTION
Since version 2021.2, PhpStorm has had basic support for generics. Thus, the "Dynamic Return Type" plugin is no longer necessary.

And: TYPO3 no longer provides the configuration file at all. It has been replaced by `.phpstorm.meta.php`.

https://github.com/typo3/typo3/commit/0999e752a2753c7bc29f0955963478ae48028d59