### PR TITLE
Remove insecure legacy SSH key workaround

### DIFF
--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -109,30 +109,6 @@ connections to `review.typo3.org`:
 
 Now the connection should work without having to specify any parameters as described above.
 
-If this does not work another issue might be that your SSH version is too new and does not
-accept the signature algorithm. You can test this by executing:
-
-..  code-block:: bash
-    :caption: shell command
-
-    ssh -v -p 29418 -i <path-to-private-key> <username>@review.typo3.org 2>&1 | grep "no mutual signature algorithm"
-
-If you see the following:
-
-..  code-block:: none
-    :caption: result
-
-    debug1: send_pubkey_test: no mutual signature algorithm
-
-you need to allow the rsa Algorithm in your SSH config:
-
-..  code-block:: text
-    :caption: ~/.ssh/config
-
-    Host review.typo3.org
-      ...
-      PubkeyAcceptedKeyTypes +ssh-rsa
-
 Push: invalid committer
 -----------------------
 


### PR DESCRIPTION
The issue was probably caused by an older Gerrit Version supporting only insecure RSA algorithms.

Since Gerrit offers rsa-sha2-256 and rsa-sha2-512 this issue should no longer occur and the potentially insecure workaround can be removed.

See also #197 where this was introduced.